### PR TITLE
Add EventRecordConstructor responsible for creating GenericRecords based on the hook type

### DIFF
--- a/WORKSPACE
+++ b/WORKSPACE
@@ -24,6 +24,18 @@ maven_install(
             neverlink = True,
         ),
         maven.artifact(
+            "org.apache.commons",
+            "commons-compress",
+            "1.10",
+            neverlink = True,
+        ),
+        maven.artifact(
+            "org.apache.hadoop",
+            "hadoop-common",
+            "2.2.0",
+            neverlink = True,
+        ),
+        maven.artifact(
             "org.apache.avro",
             "avro",
             "1.10.2",
@@ -70,6 +82,7 @@ maven_install(
         "org.apache.hadoop:hadoop-mapreduce-client-core:2.9.0",
         "org.apache.hive:hive-exec:2.2.0",
         "com.google.truth:truth:1.1.3",
+        "com.google.truth.extensions:truth-java8-extension:1.1.3",
         "org.apache.curator:apache-curator:2.7.1",
         "junit:junit:4.13.2",
         "org.mockito:mockito-core:3.11.1",

--- a/src/java/com/google/cloud/bigquery/dwhassessment/hooks/MigrationAssessmentLoggingHook.java
+++ b/src/java/com/google/cloud/bigquery/dwhassessment/hooks/MigrationAssessmentLoggingHook.java
@@ -15,23 +15,9 @@
  */
 package com.google.cloud.bigquery.dwhassessment.hooks;
 
-import static org.apache.hadoop.hive.ql.hooks.Entity.Type.PARTITION;
-import static org.apache.hadoop.hive.ql.hooks.Entity.Type.TABLE;
-
-import com.google.cloud.bigquery.dwhassessment.hooks.avro.AvroSchemaLoader;
-import com.google.cloud.bigquery.dwhassessment.hooks.logger.ExecutionMode;
-import java.util.ArrayList;
-import java.util.List;
-import java.util.Set;
-import org.apache.avro.Schema;
+import com.google.cloud.bigquery.dwhassessment.hooks.logger.EventLogger;
+import java.time.Clock;
 import org.apache.avro.generic.GenericRecord;
-import org.apache.avro.generic.GenericRecordBuilder;
-import org.apache.hadoop.hive.conf.HiveConf;
-import org.apache.hadoop.hive.ql.QueryPlan;
-import org.apache.hadoop.hive.ql.exec.Utilities;
-import org.apache.hadoop.hive.ql.exec.mr.ExecDriver;
-import org.apache.hadoop.hive.ql.exec.tez.TezTask;
-import org.apache.hadoop.hive.ql.hooks.Entity;
 import org.apache.hadoop.hive.ql.hooks.ExecuteWithHookContext;
 import org.apache.hadoop.hive.ql.hooks.HookContext;
 import org.slf4j.Logger;
@@ -42,87 +28,12 @@ public class MigrationAssessmentLoggingHook implements ExecuteWithHookContext {
 
   private static final Logger LOG = LoggerFactory.getLogger(MigrationAssessmentLoggingHook.class);
 
-  private static final Schema QUERY_EVENT_SCHEMA = AvroSchemaLoader.loadSchema("QueryEvents.avsc");
-
-  // Just for the example. Real hook will write it to the file
-  public List<GenericRecord> records = new ArrayList<>();
-
   public void run(HookContext hookContext) throws Exception {
-    processQueryEventAvro(hookContext);
-  }
-
-  private void processQueryEventAvro(HookContext hookContext) {
-    QueryPlan plan = hookContext.getQueryPlan();
-
-    LOG.info("Received hook notification for: {}", plan.getQueryId());
-
-    // Make a copy so that we do not modify hookContext conf.
-    HiveConf conf = new HiveConf(hookContext.getConf());
-    List<ExecDriver> mrTasks = Utilities.getMRTasks(plan.getRootTasks());
-    List<TezTask> tezTasks = Utilities.getTezTasks(plan.getRootTasks());
-    ExecutionMode executionMode = getExecutionMode(mrTasks, tezTasks);
-
-    GenericRecord queryEvent =
-        new GenericRecordBuilder(QUERY_EVENT_SCHEMA)
-            .set("QueryId", plan.getQueryId())
-            .set("QueryText", plan.getQueryStr())
-            .set("EventType", hookContext.getHookType().name())
-            .set("Timestamp", plan.getQueryStartTime())
-            .set("User", getUser(hookContext))
-            .set("RequestUser", getRequestUser(hookContext))
-            .set("ExecutionMode", executionMode.name())
-            .set("Queue", getQueueName(executionMode, conf))
-            .set("TablesRead", getTablesFromEntitySet(plan.getInputs()))
-            .set("TablesWritten", getTablesFromEntitySet(plan.getOutputs()))
-            .build();
-    records.add(queryEvent);
-    LOG.info("Processed record: {}", queryEvent);
-  }
-
-  private List<String> getTablesFromEntitySet(Set<? extends Entity> entities) {
-    List<String> tableNames = new ArrayList<>();
-    for (Entity entity : entities) {
-      if (entity.getType() == TABLE || entity.getType() == PARTITION) {
-        tableNames.add(entity.getTable().getCompleteName());
-      }
-    }
-    return tableNames;
-  }
-
-  private String getUser(HookContext hookContext) {
-    return hookContext.getUgi().getShortUserName();
-  }
-
-  private String getRequestUser(HookContext hookContext) {
-    String requestUser = hookContext.getUserName();
-    return requestUser == null ? hookContext.getUgi().getUserName() : requestUser;
-  }
-
-  private ExecutionMode getExecutionMode(List<ExecDriver> mrTasks, List<TezTask> tezTasks) {
-    if (tezTasks.size() > 0) {
-      // Need to go in and check if any of the tasks is running in LLAP mode.
-      for (TezTask tezTask : tezTasks) {
-        if (tezTask.getWork().getLlapMode()) {
-          return ExecutionMode.LLAP;
-        }
-      }
-      return ExecutionMode.TEZ;
-    }
-
-    return mrTasks.size() > 0 ? ExecutionMode.MR : ExecutionMode.NONE;
-  }
-
-  private String getQueueName(ExecutionMode mode, HiveConf conf) {
-    switch (mode) {
-      case LLAP:
-        return conf.get(HiveConf.ConfVars.LLAP_DAEMON_QUEUE_NAME.varname);
-      case MR:
-        return "TODO_MAPREDUCE";
-      case TEZ:
-        return "TODO_TEZ";
-      case NONE:
-      default:
-        return null;
+    try {
+      EventLogger logger = EventLogger.getInstance(hookContext.getConf(), Clock.systemUTC());
+      logger.handle(hookContext);
+    } catch (Exception e) {
+      LOG.error("Got exception while processing event", e);
     }
   }
 }

--- a/src/java/com/google/cloud/bigquery/dwhassessment/hooks/MigrationAssessmentLoggingHook.java
+++ b/src/java/com/google/cloud/bigquery/dwhassessment/hooks/MigrationAssessmentLoggingHook.java
@@ -19,6 +19,7 @@ import static org.apache.hadoop.hive.ql.hooks.Entity.Type.PARTITION;
 import static org.apache.hadoop.hive.ql.hooks.Entity.Type.TABLE;
 
 import com.google.cloud.bigquery.dwhassessment.hooks.avro.AvroSchemaLoader;
+import com.google.cloud.bigquery.dwhassessment.hooks.logger.ExecutionMode;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Set;

--- a/src/java/com/google/cloud/bigquery/dwhassessment/hooks/avro/AvroSchemaLoader.java
+++ b/src/java/com/google/cloud/bigquery/dwhassessment/hooks/avro/AvroSchemaLoader.java
@@ -35,4 +35,6 @@ public final class AvroSchemaLoader {
       throw new IllegalStateException(String.format("Error reading schema '%s'.", name), e);
     }
   }
+
+  private AvroSchemaLoader() {}
 }

--- a/src/java/com/google/cloud/bigquery/dwhassessment/hooks/avro/QueryEvents.avsc
+++ b/src/java/com/google/cloud/bigquery/dwhassessment/hooks/avro/QueryEvents.avsc
@@ -92,6 +92,110 @@
         "items": "string"
       },
       "default": []
+    },
+    {
+      "name": "Status",
+      "type": [
+        "null",
+        "string"
+      ],
+      "default": null
+    },
+    {
+      "name": "ErrorMessage",
+      "type": [
+        "null",
+        "string"
+      ],
+      "default": null
+    },
+    {
+      "name": "PerfObject",
+      "type": [
+        "null",
+        "string"
+      ],
+      "default": null
+    },
+    {
+      "name": "SessionId",
+      "type": [
+        "null",
+        "string"
+      ],
+      "default": null
+    },
+    {
+      "name": "IsTez",
+      "type": [
+        "null",
+        "boolean"
+      ],
+      "default": null
+    },
+    {
+      "name": "IsMapReduce",
+      "type": [
+        "null",
+        "boolean"
+      ],
+      "default": null
+    },
+    {
+      "name": "InvokerInfo",
+      "type": [
+        "null",
+        "string"
+      ],
+      "default": null
+    },
+    {
+      "name": "ThreadName",
+      "type": [
+        "null",
+        "string"
+      ],
+      "default": null
+    },
+    {
+      "name": "HookVersion",
+      "type": [
+        "null",
+        "string"
+      ],
+      "default": null
+    },
+    {
+      "name": "ClientIpAddress",
+      "type": [
+        "null",
+        "string"
+      ],
+      "default": null
+    },
+    {
+      "name": "HiveAddress",
+      "type": [
+        "null",
+        "string"
+      ],
+      "default": null
+    },
+    {
+      "name": "HiveInstanceType",
+      "type": [
+        "null",
+        "string"
+      ],
+      "default": null
+    },
+    {
+      "name": "LlapApplicationId",
+      "type": [
+        "null",
+        "string"
+      ],
+      "default": null
     }
   ]
 }

--- a/src/java/com/google/cloud/bigquery/dwhassessment/hooks/logger/BUILD
+++ b/src/java/com/google/cloud/bigquery/dwhassessment/hooks/logger/BUILD
@@ -11,24 +11,20 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-load("@rules_java//java:defs.bzl", "java_binary", "java_library", "java_test")
+load("@rules_java//java:defs.bzl", "java_library")
 
 package(default_visibility = ["//src:internal"])
 
 java_library(
-    name = "hooks",
+    name = "logger",
     srcs = glob(["*.java"]),
     deps = [
         "//src/java/com/google/cloud/bigquery/dwhassessment/hooks/avro",
-        "//src/java/com/google/cloud/bigquery/dwhassessment/hooks/logger",
+        "@maven//:com_google_guava_guava",
+        "@maven//:org_apache_avro_avro",
+        "@maven//:org_apache_commons_commons_compress",
+        "@maven//:org_apache_hadoop_hadoop_common",
         "@maven//:org_apache_hive_hive_exec_2_2_0",
         "@maven//:org_slf4j_slf4j_api",
-    ],
-)
-
-java_binary(
-    name = "HiveMigrationAssessmentQueryLogsHooks",
-    runtime_deps = [
-        ":hooks",
     ],
 )

--- a/src/java/com/google/cloud/bigquery/dwhassessment/hooks/logger/DatePartitionedRecordsWriterFactory.java
+++ b/src/java/com/google/cloud/bigquery/dwhassessment/hooks/logger/DatePartitionedRecordsWriterFactory.java
@@ -1,0 +1,93 @@
+/*
+ * Copyright 2022 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.google.cloud.bigquery.dwhassessment.hooks.logger;
+
+import java.io.IOException;
+import java.time.Clock;
+import java.time.LocalDate;
+import java.time.ZoneOffset;
+import java.time.format.DateTimeFormatter;
+import java.time.format.DateTimeParseException;
+import org.apache.avro.Schema;
+import org.apache.hadoop.conf.Configuration;
+import org.apache.hadoop.fs.FileSystem;
+import org.apache.hadoop.fs.Path;
+import org.apache.hadoop.fs.permission.FsPermission;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+/**
+ * Factory for {@link RecordsWriter} instances. Manages them to write to files, partitioned by
+ * dates.
+ */
+public class DatePartitionedRecordsWriterFactory {
+  private static final Logger LOG =
+      LoggerFactory.getLogger(DatePartitionedRecordsWriterFactory.class);
+  private static final FsPermission DIR_PERMISSION = FsPermission.createImmutable((short) 1023);
+  private final Path basePath;
+  private final Configuration conf;
+  private final Schema schema;
+  private final Clock clock;
+
+  public DatePartitionedRecordsWriterFactory(
+      Path baseDir, Configuration conf, Schema schema, Clock clock) throws IOException {
+    this.conf = conf;
+    this.createDirIfNotExists(baseDir);
+    this.schema = schema;
+    this.clock = clock;
+    basePath = baseDir.getFileSystem(conf).resolvePath(baseDir);
+  }
+
+  public static LocalDate getDateFromDir(String dirName) {
+    try {
+      return LocalDate.parse(dirName, DateTimeFormatter.ISO_LOCAL_DATE);
+    } catch (DateTimeParseException e) {
+      throw new IllegalArgumentException("Invalid directory: " + dirName, e);
+    }
+  }
+
+  public RecordsWriter createWriter(String fileName) throws IOException {
+    Path filePath = getPathForDate(getNow(), fileName);
+    return new RecordsWriter(conf, filePath, schema);
+  }
+
+  private void createDirIfNotExists(Path path) throws IOException {
+    FileSystem fileSystem = path.getFileSystem(conf);
+
+    try {
+      if (!fileSystem.exists(path)) {
+        fileSystem.mkdirs(path);
+        fileSystem.setPermission(path, DIR_PERMISSION);
+      }
+    } catch (IOException e) {
+      LOG.warn("Error while trying to set permission", e);
+    }
+  }
+
+  private Path getPathForDate(LocalDate date, String fileName) throws IOException {
+    Path path = new Path(basePath, getDirForDate(date));
+    createDirIfNotExists(path);
+    return new Path(path, fileName);
+  }
+
+  private String getDirForDate(LocalDate date) {
+    return DateTimeFormatter.ISO_LOCAL_DATE.format(date);
+  }
+
+  public LocalDate getNow() {
+    return clock.instant().atOffset(ZoneOffset.UTC).toLocalDate();
+  }
+}

--- a/src/java/com/google/cloud/bigquery/dwhassessment/hooks/logger/EventLogger.java
+++ b/src/java/com/google/cloud/bigquery/dwhassessment/hooks/logger/EventLogger.java
@@ -1,0 +1,242 @@
+package com.google.cloud.bigquery.dwhassessment.hooks.logger;
+
+import static com.google.cloud.bigquery.dwhassessment.hooks.logger.LoggerVarsConfig.HIVE_QUERY_EVENTS_BASE_PATH;
+import static com.google.cloud.bigquery.dwhassessment.hooks.logger.LoggerVarsConfig.HIVE_QUERY_EVENTS_QUEUE_CAPACITY;
+import static com.google.cloud.bigquery.dwhassessment.hooks.logger.LoggerVarsConfig.HIVE_QUERY_EVENTS_ROLLOVER_CHECK_INTERVAL;
+import static com.google.cloud.bigquery.dwhassessment.hooks.logger.LoggingHookConstants.QUERY_EVENT_SCHEMA;
+import static java.util.concurrent.TimeUnit.SECONDS;
+
+import java.time.Clock;
+import java.time.Duration;
+import java.util.Optional;
+import java.util.concurrent.RejectedExecutionException;
+import org.apache.avro.generic.GenericRecord;
+import org.apache.commons.compress.utils.IOUtils;
+import com.google.common.util.concurrent.ThreadFactoryBuilder;
+import java.io.IOException;
+import java.time.LocalDate;
+import java.util.UUID;
+import java.util.concurrent.ScheduledThreadPoolExecutor;
+import java.util.concurrent.ThreadFactory;
+import java.util.concurrent.TimeUnit;
+import org.apache.commons.lang3.StringUtils;
+import org.apache.hadoop.fs.Path;
+import org.apache.hadoop.hive.conf.HiveConf;
+import org.apache.hadoop.hive.ql.QueryPlan;
+import org.apache.hadoop.hive.ql.hooks.HookContext;
+import org.apache.hadoop.hive.ql.hooks.HookContext.HookType;
+import org.apache.hive.common.util.ShutdownHookManager;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+/**
+ * Main handler of query events. Processes the captured events and writes resulting records to a
+ * file.
+ */
+public class EventLogger {
+  private static final Logger LOG = LoggerFactory.getLogger(EventLogger.class);
+
+  private static final int MAX_RETRIES = 2;
+  private static final Duration SHUTDOWN_WAIT_TIME = Duration.ofSeconds(5);
+  private static final int QUERY_EVENTS_QUEUE_DEFAULT_SIZE = 64;
+  private static final Duration DEFAULT_ROLLOVER_TIME_MILLISECONDS = Duration.ofSeconds(600);
+
+  private final DatePartitionedRecordsWriterFactory logger;
+  private final EventRecordConstructor eventRecordConstructor;
+  private final ScheduledThreadPoolExecutor logWriter;
+  private final int queueCapacity;
+  private final UUID loggerId;
+
+  private int logFileCount = 0;
+  private RecordsWriter writer;
+  private LocalDate writerDate;
+
+  // Singleton using DCL.
+  private static volatile EventLogger instance;
+
+  public static EventLogger getInstance(HiveConf conf, Clock clock) {
+    if (instance == null) {
+      synchronized (EventLogger.class) {
+        if (instance == null) {
+          instance = new EventLogger(conf, clock);
+          ShutdownHookManager.addShutdownHook(instance::shutdown);
+        }
+      }
+    }
+    return instance;
+  }
+
+  protected EventLogger(HiveConf conf, Clock clock) {
+    eventRecordConstructor = new EventRecordConstructor(clock);
+    loggerId = UUID.randomUUID();
+    queueCapacity =
+        conf.getInt(
+            HIVE_QUERY_EVENTS_QUEUE_CAPACITY.getConfName(), QUERY_EVENTS_QUEUE_DEFAULT_SIZE);
+    String baseDir = conf.get(HIVE_QUERY_EVENTS_BASE_PATH.getConfName());
+
+    if (StringUtils.isBlank(baseDir)) {
+      baseDir = null;
+      LOG.error(
+          "Log dir configuration key '{}' is not set, logging disabled.",
+          HIVE_QUERY_EVENTS_QUEUE_CAPACITY.getConfName());
+    }
+
+    logger = createLogger(baseDir, conf, clock);
+    if (logger == null) {
+      logWriter = null;
+      return;
+    }
+
+    ThreadFactory threadFactory =
+        new ThreadFactoryBuilder()
+            .setDaemon(true)
+            .setNameFormat("Migration Assessment Hook Query Log Writer %d")
+            .build();
+    logWriter = new ScheduledThreadPoolExecutor(1, threadFactory);
+
+    long rolloverIntervalMilliseconds =
+        conf.getTimeDuration(
+            HIVE_QUERY_EVENTS_ROLLOVER_CHECK_INTERVAL.getConfName(),
+            DEFAULT_ROLLOVER_TIME_MILLISECONDS.toMillis(),
+            TimeUnit.MILLISECONDS);
+
+    logWriter.scheduleWithFixedDelay(
+        this::handleTick,
+        rolloverIntervalMilliseconds,
+        rolloverIntervalMilliseconds,
+        TimeUnit.MILLISECONDS);
+  }
+
+  public void handle(HookContext hookContext) {
+    if (logger == null) {
+      return;
+    }
+    // Note: same hookContext object is used for all the events for a given query, if we try to
+    // do it async we have concurrency issues and when query cache is enabled, post event comes
+    // before we start the pre hook processing and causes inconsistent events publishing.
+    QueryPlan plan = hookContext.getQueryPlan();
+    if (plan == null) {
+      LOG.debug("Received null query plan.");
+      return;
+    }
+
+    Optional<GenericRecord> maybeEvent = eventRecordConstructor.constructEvent(hookContext);
+
+    maybeEvent.ifPresent(event -> tryWriteEvent(event, hookContext.getHookType()));
+  }
+
+  private void tryWriteEvent(GenericRecord event, HookType hookType) {
+    try {
+      // ScheduledThreadPoolExecutor uses an unbounded queue which cannot be replaced with a
+      // bounded queue.
+      // Therefore, checking queue capacity manually here.
+      if (logWriter.getQueue().size() < queueCapacity) {
+        logWriter.execute(() -> writeEventWithRetries(event));
+      } else {
+        LOG.warn(
+            "Writer queue full ignoring event {} for query {}", hookType, event.get("QueryId"));
+      }
+    } catch (RejectedExecutionException e) {
+      LOG.warn("Writer queue full ignoring event {} for query {}", hookType, event.get("QueryId"));
+    }
+  }
+
+  private DatePartitionedRecordsWriterFactory createLogger(String baseDir, HiveConf conf, Clock clock) {
+    if (baseDir == null) {
+      return null;
+    }
+
+    try {
+      return new DatePartitionedRecordsWriterFactory(new Path(baseDir), conf, QUERY_EVENT_SCHEMA, clock);
+    } catch (IOException e) {
+      LOG.error("Unable to initialize logger, logging disabled.", e);
+    }
+
+    return null;
+  }
+
+  private String constructFileName() {
+    return "dwhassessment_" + loggerId + "_" + logFileCount + ".avro";
+  }
+
+  private void handleTick() {
+    try {
+      maybeRolloverWriterForDay();
+    } catch (IOException e) {
+      LOG.error("Got IOException while trying to rollover", e);
+    }
+  }
+
+  private void maybeRolloverWriterForDay() throws IOException {
+    if (writer == null || !logger.getNow().equals(writerDate)) {
+      if (writer != null) {
+        // Day changes over case, reset the logFileCount.
+        logFileCount = 0;
+        IOUtils.closeQuietly(writer);
+        writer = null;
+      }
+      // increment log file count, if creating a new writer.
+      ++logFileCount;
+      writer = logger.createWriter(constructFileName());
+      writerDate = DatePartitionedRecordsWriterFactory.getDateFromDir(writer.getPath().getParent().getName());
+    }
+  }
+
+  private void writeEventWithRetries(GenericRecord event) {
+    for (int retryCount = 0; retryCount <= MAX_RETRIES; ++retryCount) {
+      try {
+        maybeRolloverWriterForDay();
+        writer.writeMessage(event);
+        writer.flush();
+        return;
+      } catch (IOException e) {
+        // Something wrong with writer – close and reopen.
+        IOUtils.closeQuietly(writer);
+        writer = null;
+        reportRetryState(event, retryCount, e);
+        waitForRetry(retryCount);
+      }
+    }
+  }
+
+  private void reportRetryState(GenericRecord event, int retryCount, IOException writeException) {
+    if (retryCount < MAX_RETRIES) {
+      LOG.warn(
+          "Error writing proto message for query {}, eventType: {}, retryCount: {}",
+          event.get("QueryId"),
+          event.get("EventType"),
+          retryCount,
+          writeException);
+      LOG.trace("Exception", writeException);
+    } else {
+      LOG.error(
+          "Error writing proto message for query {}, eventType: {}",
+          event.get("QueryId"),
+          event.get("EventType"),
+          writeException);
+    }
+  }
+
+  private void waitForRetry(int retryCount) {
+    try {
+      // 0 seconds, for first retry assuming fs object was closed and open will fix it.
+      SECONDS.sleep((long) retryCount * retryCount);
+    } catch (InterruptedException e) {
+      Thread.currentThread().interrupt();
+      LOG.warn("Got interrupted in retry sleep.", e);
+    }
+  }
+
+  public void shutdown() {
+    if (logWriter != null) {
+      logWriter.shutdown();
+      try {
+        logWriter.awaitTermination(SHUTDOWN_WAIT_TIME.getSeconds(), SECONDS);
+      } catch (InterruptedException e) {
+        Thread.currentThread().interrupt();
+        LOG.warn("Got interrupted exception while waiting for events to be flushed", e);
+      }
+    }
+    IOUtils.closeQuietly(writer);
+  }
+}

--- a/src/java/com/google/cloud/bigquery/dwhassessment/hooks/logger/EventRecordConstructor.java
+++ b/src/java/com/google/cloud/bigquery/dwhassessment/hooks/logger/EventRecordConstructor.java
@@ -1,0 +1,218 @@
+/*
+ * Copyright 2022 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.google.cloud.bigquery.dwhassessment.hooks.logger;
+
+import static com.google.cloud.bigquery.dwhassessment.hooks.logger.LoggerVarsConfig.MR_QUEUE_NAME;
+import static com.google.cloud.bigquery.dwhassessment.hooks.logger.LoggerVarsConfig.TEZ_QUEUE_NAME;
+import static com.google.cloud.bigquery.dwhassessment.hooks.logger.LoggingHookConstants.HOOK_VERSION;
+import static com.google.cloud.bigquery.dwhassessment.hooks.logger.LoggingHookConstants.QUERY_EVENT_SCHEMA;
+import static org.apache.hadoop.hive.ql.hooks.Entity.Type.PARTITION;
+import static org.apache.hadoop.hive.ql.hooks.Entity.Type.TABLE;
+
+import java.io.IOException;
+import java.net.InetAddress;
+import java.net.UnknownHostException;
+import java.time.Clock;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Optional;
+import java.util.Set;
+import org.apache.avro.generic.GenericRecord;
+import org.apache.avro.generic.GenericRecordBuilder;
+import org.apache.hadoop.hive.conf.HiveConf;
+import org.apache.hadoop.hive.llap.registry.impl.LlapRegistryService;
+import org.apache.hadoop.hive.ql.QueryPlan;
+import org.apache.hadoop.hive.ql.exec.Utilities;
+import org.apache.hadoop.hive.ql.exec.mr.ExecDriver;
+import org.apache.hadoop.hive.ql.exec.tez.TezTask;
+import org.apache.hadoop.hive.ql.hooks.Entity;
+import org.apache.hadoop.hive.ql.hooks.HookContext;
+import org.json.JSONObject;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+/** Constructor for generic records for given hook event. */
+public class EventRecordConstructor {
+  private static final Logger LOG = LoggerFactory.getLogger(EventRecordConstructor.class);
+
+  private final Clock clock;
+
+  public EventRecordConstructor(Clock clock) {
+    this.clock = clock;
+  }
+
+  /** Constructs a record with information specific to a hook type */
+  public Optional<GenericRecord> constructEvent(HookContext hookContext) {
+    switch (hookContext.getHookType()) {
+      case PRE_EXEC_HOOK:
+        return Optional.of(getPreHookEvent(hookContext));
+      case POST_EXEC_HOOK:
+        return Optional.of(getPostHookEvent(hookContext, EventStatus.SUCCESS));
+      case ON_FAILURE_HOOK:
+        return Optional.of(getPostHookEvent(hookContext, EventStatus.FAIL));
+    }
+
+    LOG.warn("Ignoring event of type: {}", hookContext.getHookType());
+    return Optional.empty();
+  }
+
+  private GenericRecord getPreHookEvent(HookContext hookContext) {
+    QueryPlan plan = hookContext.getQueryPlan();
+
+    // Make a copy so that we do not modify hookContext conf.
+    HiveConf conf = new HiveConf(hookContext.getConf());
+    List<ExecDriver> mrTasks = Utilities.getMRTasks(plan.getRootTasks());
+    List<TezTask> tezTasks = Utilities.getTezTasks(plan.getRootTasks());
+    ExecutionMode executionMode = getExecutionMode(mrTasks, tezTasks);
+
+    return new GenericRecordBuilder(QUERY_EVENT_SCHEMA)
+        .set("QueryId", plan.getQueryId())
+        .set("QueryText", plan.getQueryStr())
+        .set("EventType", EventType.QUERY_SUBMITTED.name())
+        .set("Timestamp", plan.getQueryStartTime())
+        .set("User", getUser(hookContext))
+        .set("RequestUser", getRequestUser(hookContext))
+        .set("ExecutionMode", executionMode.name())
+        .set("Queue", getQueueName(executionMode, conf))
+        .set("TablesRead", getTablesFromEntitySet(plan.getInputs()))
+        .set("TablesWritten", getTablesFromEntitySet(plan.getOutputs()))
+        .set("IsMapReduce", mrTasks.size() > 0)
+        .set("IsTez", tezTasks.size() > 0)
+        .set("SessionId", hookContext.getSessionId())
+        .set("InvokerInfo", conf.getLogIdVar(hookContext.getSessionId()))
+        .set("ThreadName", hookContext.getThreadId())
+        .set("ClientIpAddress", hookContext.getIpAddress())
+        .set("ClientIpAddress", hookContext.getIpAddress())
+        .set("HookVersion", HOOK_VERSION)
+        .set("HiveAddress", getHiveInstanceAddress(hookContext))
+        .set("HiveInstanceType", getHiveInstanceType(hookContext))
+        .set("LlapApplicationId", determineLlapId(conf, executionMode))
+        .set("OperationId", hookContext.getOperationId())
+        .build();
+  }
+
+  private GenericRecord getPostHookEvent(HookContext hookContext, EventStatus status) {
+    QueryPlan plan = hookContext.getQueryPlan();
+    LOG.info("Received post-hook notification for: {}", plan.getQueryId());
+
+    GenericRecordBuilder eventBuilder =
+        new GenericRecordBuilder(QUERY_EVENT_SCHEMA)
+            .set("QueryId", plan.getQueryId())
+            .set("EventType", EventType.QUERY_COMPLETED.name())
+            .set("Timestamp", clock.millis())
+            .set("User", getUser(hookContext))
+            .set("RequestUser", getRequestUser(hookContext))
+            .set("Status", status.name())
+            .set("ErrorMessage", hookContext.getErrorMessage())
+            .set("HookVersion", HOOK_VERSION)
+            .set("OperationId", hookContext.getOperationId());
+
+    JSONObject perfObj = new JSONObject();
+    for (String key : hookContext.getPerfLogger().getEndTimes().keySet()) {
+      perfObj.put(key, hookContext.getPerfLogger().getDuration(key));
+    }
+
+    eventBuilder.set("PerfObject", perfObj.toString());
+
+    return eventBuilder.build();
+  }
+
+  private static List<String> getTablesFromEntitySet(Set<? extends Entity> entities) {
+    List<String> tableNames = new ArrayList<>();
+    for (Entity entity : entities) {
+      if (entity.getType() == TABLE || entity.getType() == PARTITION) {
+        tableNames.add(entity.getTable().getDbName() + "." + entity.getTable().getTableName());
+      }
+    }
+    return tableNames;
+  }
+
+  private static String getUser(HookContext hookContext) {
+    return hookContext.getUgi().getShortUserName();
+  }
+
+  private static String getRequestUser(HookContext hookContext) {
+    String requestUser = hookContext.getUserName();
+    return requestUser == null ? hookContext.getUgi().getUserName() : requestUser;
+  }
+
+  private static ExecutionMode getExecutionMode(List<ExecDriver> mrTasks, List<TezTask> tezTasks) {
+    if (tezTasks.size() > 0) {
+      // Need to go in and check if any of the tasks is running in LLAP mode.
+      for (TezTask tezTask : tezTasks) {
+        if (tezTask.getWork().getLlapMode()) {
+          return ExecutionMode.LLAP;
+        }
+      }
+      return ExecutionMode.TEZ;
+    } else if (mrTasks.size() > 0) {
+      return ExecutionMode.MR;
+    } else {
+      return ExecutionMode.NONE;
+    }
+  }
+
+  private static String getQueueName(ExecutionMode mode, HiveConf conf) {
+    switch (mode) {
+      case LLAP:
+        return conf.get(HiveConf.ConfVars.LLAP_DAEMON_QUEUE_NAME.varname);
+      case MR:
+        return conf.get(MR_QUEUE_NAME.getConfName());
+      case TEZ:
+        return conf.get(TEZ_QUEUE_NAME.getConfName());
+      case NONE:
+      default:
+        return null;
+    }
+  }
+
+  private static String getHiveInstanceAddress(HookContext hookContext) {
+    String hiveInstanceAddress = hookContext.getHiveInstanceAddress();
+    if (hiveInstanceAddress == null) {
+      try {
+        hiveInstanceAddress = InetAddress.getLocalHost().getHostAddress();
+      } catch (UnknownHostException e) {
+        LOG.error("Error trying to get localhost address: ", e);
+      }
+    }
+    return hiveInstanceAddress;
+  }
+
+  private static String getHiveInstanceType(HookContext hookContext) {
+    return hookContext.isHiveServerQuery() ? "HS2" : "CLI";
+  }
+
+  private static String determineLlapId(HiveConf conf, ExecutionMode mode) {
+    // Note: for now, LLAP is only supported in Tez tasks. Will never come to MR; others may
+    // be added here, although this is only necessary to have extra debug information.
+    if (mode == ExecutionMode.LLAP) {
+      // In HS2, the client should have been cached already for the common case.
+      // Otherwise, this may actually introduce delay to compilation for the first query.
+      String hosts = HiveConf.getVar(conf, HiveConf.ConfVars.LLAP_DAEMON_SERVICE_HOSTS);
+      if (hosts != null && !hosts.isEmpty()) {
+        try {
+          return LlapRegistryService.getClient(conf).getApplicationId().toString();
+        } catch (IOException e) {
+          LOG.error("Error trying to get llap instance: ", e);
+        }
+      } else {
+        LOG.info("Cannot determine LLAP instance on client - service hosts are not set");
+      }
+    }
+
+    return null;
+  }
+}

--- a/src/java/com/google/cloud/bigquery/dwhassessment/hooks/logger/EventRecordConstructor.java
+++ b/src/java/com/google/cloud/bigquery/dwhassessment/hooks/logger/EventRecordConstructor.java
@@ -134,7 +134,7 @@ public class EventRecordConstructor {
     List<String> tableNames = new ArrayList<>();
     for (Entity entity : entities) {
       if (entity.getType() == TABLE || entity.getType() == PARTITION) {
-        tableNames.add(entity.getTable().getDbName() + "." + entity.getTable().getTableName());
+        tableNames.add(entity.getTable().getCompleteName());
       }
     }
     return tableNames;
@@ -185,7 +185,7 @@ public class EventRecordConstructor {
       try {
         hiveInstanceAddress = InetAddress.getLocalHost().getHostAddress();
       } catch (UnknownHostException e) {
-        LOG.error("Error trying to get localhost address: ", e);
+        LOG.error("Error trying to get localhost address", e);
       }
     }
     return hiveInstanceAddress;
@@ -206,7 +206,7 @@ public class EventRecordConstructor {
         try {
           return LlapRegistryService.getClient(conf).getApplicationId().toString();
         } catch (IOException e) {
-          LOG.error("Error trying to get llap instance: ", e);
+          LOG.error("Error trying to get llap instance. Hosts: {}", hosts, e);
         }
       } else {
         LOG.info("Cannot determine LLAP instance on client - service hosts are not set");

--- a/src/java/com/google/cloud/bigquery/dwhassessment/hooks/logger/EventStatus.java
+++ b/src/java/com/google/cloud/bigquery/dwhassessment/hooks/logger/EventStatus.java
@@ -13,16 +13,10 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package com.google.cloud.bigquery.dwhassessment.hooks;
+package com.google.cloud.bigquery.dwhassessment.hooks.logger;
 
-/**
- * Query execution mode.
- *
- * <p>Equal to Apache Hive HiveProtoLoggingHook.ExecutionMode enum
- */
-public enum ExecutionMode {
-  MR,
-  TEZ,
-  LLAP,
-  NONE
+/** Completed query event status. */
+public enum EventStatus {
+  SUCCESS,
+  FAIL,
 }

--- a/src/java/com/google/cloud/bigquery/dwhassessment/hooks/logger/EventType.java
+++ b/src/java/com/google/cloud/bigquery/dwhassessment/hooks/logger/EventType.java
@@ -1,0 +1,24 @@
+/*
+ * Copyright 2022 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.google.cloud.bigquery.dwhassessment.hooks.logger;
+
+/** Query event type, captured by hook. */
+public enum EventType {
+  QUERY_SUBMITTED,
+  QUERY_COMPLETED,
+}
+
+

--- a/src/java/com/google/cloud/bigquery/dwhassessment/hooks/logger/ExecutionMode.java
+++ b/src/java/com/google/cloud/bigquery/dwhassessment/hooks/logger/ExecutionMode.java
@@ -1,0 +1,28 @@
+/*
+ * Copyright 2022 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.google.cloud.bigquery.dwhassessment.hooks.logger;
+
+/**
+ * Query execution mode.
+ *
+ * <p>Equal to Apache Hive HiveProtoLoggingHook.ExecutionMode enum
+ */
+public enum ExecutionMode {
+  MR,
+  TEZ,
+  LLAP,
+  NONE
+}

--- a/src/java/com/google/cloud/bigquery/dwhassessment/hooks/logger/LoggerVarsConfig.java
+++ b/src/java/com/google/cloud/bigquery/dwhassessment/hooks/logger/LoggerVarsConfig.java
@@ -1,0 +1,50 @@
+/*
+ * Copyright 2022 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.google.cloud.bigquery.dwhassessment.hooks.logger;
+
+/** Stores configuration keys used by the hook. */
+public enum LoggerVarsConfig {
+
+  /** ConfName is equal to {@code org.apache.tez.dag.api.TezConfiguration.TEZ_QUEUE_NAME} */
+  TEZ_QUEUE_NAME("tez.queue.name", "Name of the TEZ default queue"),
+  /** ConfName is equal to {@code org.apache.hadoop.mapreduce.MRJobConfig.QUEUE_NAME} */
+  MR_QUEUE_NAME("mapreduce.job.queuename", "Name of the MapReduce default queue"),
+  HIVE_QUERY_EVENTS_QUEUE_CAPACITY(
+      "dwhassessment.hook.queue.capacity",
+      "Queue capacity for the query events logging threads, e.g. 100."),
+  HIVE_QUERY_EVENTS_BASE_PATH(
+      "dwhassessment.hook.base-directory",
+      "Base directory for query event messages written by Migration Assessment hook."),
+  HIVE_QUERY_EVENTS_ROLLOVER_CHECK_INTERVAL(
+      "dwhassessment.hook.rollover-interval",
+      "Frequency at which the file rollover check is triggered, e.g. 600s.");
+
+  private final String confName;
+  private final String description;
+
+  LoggerVarsConfig(String confName, String description) {
+    this.confName = confName;
+    this.description = description;
+  }
+
+  public String getConfName() {
+    return confName;
+  }
+
+  public String getDescription() {
+    return description;
+  }
+}

--- a/src/java/com/google/cloud/bigquery/dwhassessment/hooks/logger/LoggingHookConstants.java
+++ b/src/java/com/google/cloud/bigquery/dwhassessment/hooks/logger/LoggingHookConstants.java
@@ -1,0 +1,13 @@
+package com.google.cloud.bigquery.dwhassessment.hooks.logger;
+
+import com.google.cloud.bigquery.dwhassessment.hooks.avro.AvroSchemaLoader;
+import org.apache.avro.Schema;
+
+public final class LoggingHookConstants {
+
+  public static final Schema QUERY_EVENT_SCHEMA = AvroSchemaLoader.loadSchema("QueryEvents.avsc");
+
+  public static final String HOOK_VERSION = "1.0";
+
+  private LoggingHookConstants() {}
+}

--- a/src/java/com/google/cloud/bigquery/dwhassessment/hooks/logger/RecordsWriter.java
+++ b/src/java/com/google/cloud/bigquery/dwhassessment/hooks/logger/RecordsWriter.java
@@ -1,0 +1,61 @@
+/*
+ * Copyright 2022 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.google.cloud.bigquery.dwhassessment.hooks.logger;
+
+import java.io.Closeable;
+import java.io.IOException;
+import org.apache.avro.Schema;
+import org.apache.avro.file.DataFileWriter;
+import org.apache.avro.generic.GenericDatumWriter;
+import org.apache.avro.generic.GenericRecord;
+import org.apache.avro.io.DatumWriter;
+import org.apache.hadoop.conf.Configuration;
+import org.apache.hadoop.fs.FSDataOutputStream;
+import org.apache.hadoop.fs.FileSystem;
+import org.apache.hadoop.fs.Path;
+
+/** Writes {@link GenericRecord} messages to a given file. */
+public class RecordsWriter implements Closeable {
+  private final Path filePath;
+  private final DataFileWriter<GenericRecord> dataFileWriter;
+
+  RecordsWriter(Configuration conf, Path filePath, Schema schema) throws IOException {
+    this.filePath = filePath;
+    DatumWriter<GenericRecord> datumWriter = new GenericDatumWriter<>(schema);
+    dataFileWriter = new DataFileWriter<>(datumWriter);
+
+    FileSystem fs = filePath.getFileSystem(conf);
+
+    FSDataOutputStream outputStream = fs.create(filePath, true);
+    dataFileWriter.create(schema, outputStream);
+  }
+
+  public Path getPath() {
+    return filePath;
+  }
+
+  public void writeMessage(GenericRecord message) throws IOException {
+    dataFileWriter.append(message);
+  }
+
+  public void flush() throws IOException {
+    dataFileWriter.flush();
+  }
+
+  public void close() throws IOException {
+    dataFileWriter.close();
+  }
+}

--- a/src/javatests/com/google/cloud/bigquery/dwhassessment/hooks/BUILD
+++ b/src/javatests/com/google/cloud/bigquery/dwhassessment/hooks/BUILD
@@ -20,6 +20,7 @@ java_library(
     deps = [
         "//src/java/com/google/cloud/bigquery/dwhassessment/hooks",
         "//src/java/com/google/cloud/bigquery/dwhassessment/hooks/avro",
+        "//src/java/com/google/cloud/bigquery/dwhassessment/hooks/logger",
         "@maven_tests//:com_google_truth_truth",
         "@maven_tests//:junit_junit",
         "@maven_tests//:org_apache_hadoop_hadoop_common",

--- a/src/javatests/com/google/cloud/bigquery/dwhassessment/hooks/logger/BUILD
+++ b/src/javatests/com/google/cloud/bigquery/dwhassessment/hooks/logger/BUILD
@@ -1,0 +1,43 @@
+# Copyright 2022 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+load("@rules_java//java:defs.bzl", "java_library", "java_test")
+
+java_library(
+    name = "tests",
+    testonly = 1,
+    srcs = glob(["*.java"]),
+    deps = [
+        "//src/java/com/google/cloud/bigquery/dwhassessment/hooks/avro",
+        "//src/java/com/google/cloud/bigquery/dwhassessment/hooks/logger",
+        "@maven_tests//:com_google_truth_extensions_truth_java8_extension",
+        "@maven_tests//:com_google_truth_truth",
+        "@maven_tests//:junit_junit",
+        "@maven_tests//:org_apache_hadoop_hadoop_common",
+        "@maven_tests//:org_apache_hadoop_hadoop_mapreduce_client_common",
+        "@maven_tests//:org_apache_hadoop_hadoop_yarn_common",
+        "@maven_tests//:org_apache_hive_hive_common",
+        "@maven_tests//:org_apache_hive_hive_exec",
+        "@maven_tests//:org_mockito_mockito_core",
+        "@maven_tests//:org_slf4j_slf4j_api",
+    ],
+)
+
+java_test(
+    name = "EventRecordConstructorTest",
+    size = "small",
+    test_class = "com.google.cloud.bigquery.dwhassessment.hooks.logger.EventRecordConstructorTest",
+    runtime_deps = [
+        ":tests",
+    ],
+)

--- a/src/javatests/com/google/cloud/bigquery/dwhassessment/hooks/logger/BUILD
+++ b/src/javatests/com/google/cloud/bigquery/dwhassessment/hooks/logger/BUILD
@@ -41,3 +41,30 @@ java_test(
         ":tests",
     ],
 )
+
+java_test(
+    name = "RecordsWriterTest",
+    size = "small",
+    test_class = "com.google.cloud.bigquery.dwhassessment.hooks.logger.RecordsWriterTest",
+    runtime_deps = [
+        ":tests",
+    ],
+)
+
+java_test(
+    name = "DatePartitionedRecordsWriterFactoryTest",
+    size = "small",
+    test_class = "com.google.cloud.bigquery.dwhassessment.hooks.logger.DatePartitionedRecordsWriterFactoryTest",
+    runtime_deps = [
+        ":tests",
+    ],
+)
+
+java_test(
+    name = "EventLoggerTest",
+    size = "small",
+    test_class = "com.google.cloud.bigquery.dwhassessment.hooks.logger.EventLoggerTest",
+    runtime_deps = [
+        ":tests",
+    ],
+)

--- a/src/javatests/com/google/cloud/bigquery/dwhassessment/hooks/logger/DatePartitionedRecordsWriterFactoryTest.java
+++ b/src/javatests/com/google/cloud/bigquery/dwhassessment/hooks/logger/DatePartitionedRecordsWriterFactoryTest.java
@@ -1,0 +1,96 @@
+package com.google.cloud.bigquery.dwhassessment.hooks.logger;
+
+import static com.google.cloud.bigquery.dwhassessment.hooks.logger.LoggingHookConstants.QUERY_EVENT_SCHEMA;
+import static com.google.common.truth.Truth.assertThat;
+import static org.junit.Assert.assertThrows;
+
+import java.io.IOException;
+import java.time.Clock;
+import java.time.Instant;
+import java.time.LocalDate;
+import java.time.ZoneOffset;
+import org.apache.hadoop.fs.FileSystem;
+import org.apache.hadoop.fs.Path;
+import org.apache.hadoop.hive.conf.HiveConf;
+import org.junit.Before;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.rules.TemporaryFolder;
+import org.junit.runner.RunWith;
+import org.junit.runners.JUnit4;
+import org.mockito.junit.MockitoJUnit;
+import org.mockito.junit.MockitoRule;
+
+@RunWith(JUnit4.class)
+public class DatePartitionedRecordsWriterFactoryTest {
+  @Rule public MockitoRule mocks = MockitoJUnit.rule();
+
+  @Rule public TemporaryFolder folder = new TemporaryFolder();
+
+  private HiveConf conf;
+  private String tmpFolder;
+
+  @Before
+  public void setup() throws IOException {
+    conf = new HiveConf();
+    tmpFolder = folder.newFolder().getAbsolutePath();
+  }
+
+  @Test
+  public void constructor_createsDirectoryIfNotExists() throws Exception {
+    Clock fixedClock = Clock.fixed(Instant.ofEpochMilli(123L), ZoneOffset.UTC);
+    Path targetDirectoryPath = new Path(tmpFolder, "test_directory");
+    FileSystem fs = targetDirectoryPath.getFileSystem(conf);
+    boolean existedBefore = fs.exists(targetDirectoryPath);
+
+    // Act
+    new DatePartitionedRecordsWriterFactory(targetDirectoryPath, conf, QUERY_EVENT_SCHEMA, fixedClock);
+
+    // Assert
+    assertThat(fs.exists(targetDirectoryPath)).isTrue();
+    assertThat(existedBefore).isFalse();
+  }
+
+  @Test
+  public void getWriter_createsRecordWriterForCurrentDateDirectory() throws Exception {
+    Instant fixedInstant = Instant.ofEpochMilli(1293285023000L);
+    LocalDate targetDate = fixedInstant.atOffset(ZoneOffset.UTC).toLocalDate();
+    Path targetDirectoryPath = new Path(tmpFolder, targetDate.toString());
+    FileSystem fs = targetDirectoryPath.getFileSystem(conf);
+    boolean existedBefore = fs.exists(targetDirectoryPath);
+    DatePartitionedRecordsWriterFactory datePartitionedRecordsWriterFactory =
+        new DatePartitionedRecordsWriterFactory(
+            new Path(tmpFolder),
+            conf,
+            QUERY_EVENT_SCHEMA,
+            Clock.fixed(fixedInstant, ZoneOffset.UTC));
+
+    // Act
+    RecordsWriter writer = datePartitionedRecordsWriterFactory.createWriter("test_filename.avro");
+
+    // Assert
+    assertThat(writer.getPath())
+        .isEqualTo(
+            new Path(
+                targetDirectoryPath.getFileSystem(conf).resolvePath(targetDirectoryPath),
+                "test_filename.avro"));
+    assertThat(fs.exists(targetDirectoryPath)).isTrue();
+    assertThat(existedBefore).isFalse();
+  }
+
+  @Test
+  public void getDateFromDir_success() {
+    LocalDate expected = LocalDate.of(2022, 12, 8);
+
+    assertThat(DatePartitionedRecordsWriterFactory.getDateFromDir("2022-12-08")).isEqualTo(expected);
+  }
+
+  @Test
+  public void getDateFromDir_invalidDirectoryName_fail() {
+    IllegalArgumentException e =
+        assertThrows(
+            IllegalArgumentException.class, () -> DatePartitionedRecordsWriterFactory.getDateFromDir("test"));
+
+    assertThat(e).hasMessageThat().isEqualTo("Invalid directory: test");
+  }
+}

--- a/src/javatests/com/google/cloud/bigquery/dwhassessment/hooks/logger/EventRecordConstructorTest.java
+++ b/src/javatests/com/google/cloud/bigquery/dwhassessment/hooks/logger/EventRecordConstructorTest.java
@@ -1,0 +1,167 @@
+package com.google.cloud.bigquery.dwhassessment.hooks.logger;
+
+
+import static com.google.cloud.bigquery.dwhassessment.hooks.logger.LoggingHookConstants.QUERY_EVENT_SCHEMA;
+import static com.google.common.truth.Truth8.assertThat;
+
+import java.time.Clock;
+import java.time.Instant;
+import java.time.ZoneId;
+import java.util.Optional;
+import org.apache.avro.generic.GenericRecord;
+import org.apache.avro.generic.GenericRecordBuilder;
+import org.apache.hadoop.hive.conf.HiveConf;
+import org.apache.hadoop.hive.ql.QueryPlan;
+import org.apache.hadoop.hive.ql.QueryState;
+import org.apache.hadoop.hive.ql.hooks.HookContext;
+import org.apache.hadoop.hive.ql.hooks.HookContext.HookType;
+import org.apache.hadoop.hive.ql.log.PerfLogger;
+import org.apache.hadoop.hive.ql.metadata.Hive;
+import org.apache.hadoop.hive.ql.parse.BaseSemanticAnalyzer;
+import org.apache.hadoop.hive.ql.parse.DDLSemanticAnalyzer;
+import org.apache.hadoop.hive.ql.plan.HiveOperation;
+import org.junit.Before;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.junit.runners.JUnit4;
+import org.mockito.Mock;
+import org.mockito.junit.MockitoJUnit;
+import org.mockito.junit.MockitoRule;
+
+@RunWith(JUnit4.class)
+public class EventRecordConstructorTest {
+
+  @Rule
+  public MockitoRule mocks = MockitoJUnit.rule();
+
+  @Mock
+  Hive hiveMock;
+
+  private QueryState queryState;
+  private HiveConf conf;
+
+  private EventRecordConstructor eventRecordConstructor;
+
+  private static final long QUERY_END_TIME = 9999L;
+
+  @Before
+  public void setup() {
+    conf = new HiveConf();
+    queryState = new QueryState(conf);
+
+    Clock fixedClock = Clock.fixed(Instant.ofEpochMilli(QUERY_END_TIME), ZoneId.of("UTC"));
+    eventRecordConstructor = new EventRecordConstructor(fixedClock);
+  }
+
+  @Test
+  public void preExecHook_success() throws Exception {
+    String queryText = "SELECT * FROM employees";
+    String queryId = "hive_query_id_999";
+    QueryPlan queryPlan = createQueryPlan(queryText, queryId);
+    HookContext context = createContext(queryPlan);
+    context.setHookType(HookType.PRE_EXEC_HOOK);
+
+    // Act
+    Optional<GenericRecord> record = eventRecordConstructor.constructEvent(context);
+
+    // Assert
+    assertThat(record)
+        .hasValue(
+            new GenericRecordBuilder(QUERY_EVENT_SCHEMA)
+                .set("QueryId", queryId)
+                .set("QueryText", queryText)
+                .set("EventType", "QUERY_SUBMITTED")
+                .set("ExecutionMode", "NONE")
+                .set("Timestamp", 1234L)
+                .set("RequestUser", "test_user")
+                .set("User", System.getProperty("user.name"))
+                .set("SessionId", "test_session_id")
+                .set("IsTez", false)
+                .set("IsMapReduce", false)
+                .set("InvokerInfo", "test_session_id")
+                .set("ThreadName", "test_thread_id")
+                .set("HookVersion", "1.0")
+                .set("ClientIpAddress", "192.168.10.10")
+                .set("HiveAddress", "hive_addr")
+                .set("HiveInstanceType", "HS2")
+                .set("OperationId", "test_op_id")
+                .build());
+  }
+
+  @Test
+  public void postExecHook_success() throws Exception {
+    String queryText = "SELECT * FROM employees";
+    String queryId = "hive_query_id_999";
+    QueryPlan queryPlan = createQueryPlan(queryText, queryId);
+    HookContext context = createContext(queryPlan);
+    context.setHookType(HookType.POST_EXEC_HOOK);
+
+    // Act
+    Optional<GenericRecord> record = eventRecordConstructor.constructEvent(context);
+
+    // Assert
+    assertThat(record)
+        .hasValue(
+            new GenericRecordBuilder(QUERY_EVENT_SCHEMA)
+                .set("QueryId", queryId)
+                .set("EventType", "QUERY_COMPLETED")
+                .set("Timestamp", QUERY_END_TIME)
+                .set("RequestUser", "test_user")
+                .set("User", System.getProperty("user.name"))
+                .set("OperationId", "test_op_id")
+                .set("Status", "SUCCESS")
+                .set("PerfObject", "{}")
+                .set("HookVersion", "1.0")
+                .build());
+  }
+
+  @Test
+  public void onFailureHook_success() throws Exception {
+    String queryText = "SELECT * FROM employees";
+    String queryId = "hive_query_id_999";
+    QueryPlan queryPlan = createQueryPlan(queryText, queryId);
+    HookContext context = createContext(queryPlan);
+    context.setHookType(HookType.ON_FAILURE_HOOK);
+
+    // Act
+    Optional<GenericRecord> record = eventRecordConstructor.constructEvent(context);
+
+    // Assert
+    assertThat(record)
+        .hasValue(
+            new GenericRecordBuilder(QUERY_EVENT_SCHEMA)
+                .set("QueryId", queryId)
+                .set("EventType", "QUERY_COMPLETED")
+                .set("Timestamp", QUERY_END_TIME)
+                .set("RequestUser", "test_user")
+                .set("User", System.getProperty("user.name"))
+                .set("OperationId", "test_op_id")
+                .set("Status", "FAIL")
+                .set("PerfObject", "{}")
+                .set("HookVersion", "1.0")
+                .build());
+  }
+
+  private HookContext createContext(QueryPlan queryPlan) throws Exception {
+    PerfLogger perfLogger = PerfLogger.getPerfLogger(conf, true);
+    return new HookContext(
+        queryPlan,
+        queryState,
+        null,
+        "test_user",
+        "192.168.10.10",
+        "hive_addr",
+        "test_op_id",
+        "test_session_id",
+        "test_thread_id",
+        true,
+        perfLogger);
+  }
+
+  private QueryPlan createQueryPlan(String queryText, String queryId) throws Exception {
+    BaseSemanticAnalyzer sem = new DDLSemanticAnalyzer(queryState, hiveMock);
+
+    return new QueryPlan(queryText, sem, 1234L, queryId, HiveOperation.QUERY, null);
+  }
+}

--- a/src/javatests/com/google/cloud/bigquery/dwhassessment/hooks/logger/EventRecordConstructorTest.java
+++ b/src/javatests/com/google/cloud/bigquery/dwhassessment/hooks/logger/EventRecordConstructorTest.java
@@ -6,7 +6,7 @@ import static com.google.common.truth.Truth8.assertThat;
 
 import java.time.Clock;
 import java.time.Instant;
-import java.time.ZoneId;
+import java.time.ZoneOffset;
 import java.util.Optional;
 import org.apache.avro.generic.GenericRecord;
 import org.apache.avro.generic.GenericRecordBuilder;
@@ -50,7 +50,7 @@ public class EventRecordConstructorTest {
     conf = new HiveConf();
     queryState = new QueryState(conf);
 
-    Clock fixedClock = Clock.fixed(Instant.ofEpochMilli(QUERY_END_TIME), ZoneId.of("UTC"));
+    Clock fixedClock = Clock.fixed(Instant.ofEpochMilli(QUERY_END_TIME), ZoneOffset.UTC);
     eventRecordConstructor = new EventRecordConstructor(fixedClock);
   }
 

--- a/src/javatests/com/google/cloud/bigquery/dwhassessment/hooks/logger/RecordsWriterTest.java
+++ b/src/javatests/com/google/cloud/bigquery/dwhassessment/hooks/logger/RecordsWriterTest.java
@@ -1,0 +1,99 @@
+package com.google.cloud.bigquery.dwhassessment.hooks.logger;
+
+import static com.google.cloud.bigquery.dwhassessment.hooks.logger.LoggingHookConstants.QUERY_EVENT_SCHEMA;
+import static com.google.common.truth.Truth.assertThat;
+
+import java.io.IOException;
+import java.util.ArrayList;
+import java.util.List;
+import org.apache.avro.file.DataFileStream;
+import org.apache.avro.generic.GenericDatumReader;
+import org.apache.avro.generic.GenericRecord;
+import org.apache.avro.generic.GenericRecordBuilder;
+import org.apache.avro.io.DatumReader;
+import org.apache.hadoop.fs.FSDataInputStream;
+import org.apache.hadoop.fs.FileSystem;
+import org.apache.hadoop.fs.Path;
+import org.apache.hadoop.hive.conf.HiveConf;
+import org.junit.Before;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.rules.TemporaryFolder;
+import org.junit.runner.RunWith;
+import org.junit.runners.JUnit4;
+import org.mockito.junit.MockitoJUnit;
+import org.mockito.junit.MockitoRule;
+
+@RunWith(JUnit4.class)
+public class RecordsWriterTest {
+  @Rule
+  public MockitoRule mocks = MockitoJUnit.rule();
+
+  @Rule
+  public TemporaryFolder folder = new TemporaryFolder();
+
+  private HiveConf conf;
+  private Path outputFilePath;
+
+  private RecordsWriter recordsWriter;
+
+  @Before
+  public void setup() throws IOException {
+    conf = new HiveConf();
+    outputFilePath = new Path(folder.newFolder().getAbsolutePath(), "temp_file.avro");
+    recordsWriter = new RecordsWriter(conf, outputFilePath, QUERY_EVENT_SCHEMA);
+  }
+
+  @Test
+  public void writeMessage_singleMessageSuccess() throws Exception {
+    GenericRecord message = createMessage("test_id_1");
+
+    // Act
+    recordsWriter.writeMessage(message);
+    recordsWriter.close();
+
+    // Assert
+    List<GenericRecord> records = readOutputRecords(conf, outputFilePath);
+    assertThat(records).containsExactly(message);
+  }
+
+  @Test
+  public void writeMessage_multipleMessageSuccess() throws Exception {
+    GenericRecord message1 = createMessage("test_id_1");
+    GenericRecord message2 = createMessage("test_id_2");
+
+    // Act
+    recordsWriter.writeMessage(message1);
+    recordsWriter.writeMessage(message2);
+    recordsWriter.close();
+
+    // Assert
+    List<GenericRecord> records = readOutputRecords(conf, outputFilePath);
+    assertThat(records).containsExactly(message1, message2);
+  }
+
+  @Test
+  public void getPath_success() {
+    assertThat(recordsWriter.getPath()).isEqualTo(outputFilePath);
+  }
+
+  private static List<GenericRecord> readOutputRecords(HiveConf conf, Path outputFilePath)
+      throws IOException {
+    FileSystem fs = outputFilePath.getFileSystem(conf);
+    FSDataInputStream inputStream = fs.open(outputFilePath);
+
+    DatumReader<GenericRecord> reader = new GenericDatumReader<>(QUERY_EVENT_SCHEMA);
+
+    try (DataFileStream<GenericRecord> dataFileReader = new DataFileStream<>(inputStream, reader)) {
+      List<GenericRecord> records = new ArrayList<>();
+      dataFileReader.forEach(records::add);
+      return records;
+    }
+  }
+
+  private GenericRecord createMessage(String id) {
+    return new GenericRecordBuilder(QUERY_EVENT_SCHEMA)
+        .set("QueryId", id)
+        .build();
+  }
+}


### PR DESCRIPTION
This is a first PR of actual logging hook migration. 

QueryEvent schema mostly mirrors the [HiveProtoEvents](https://github.com/apache/hive/blob/master/ql/src/protobuf/java/HiveEvents.proto). The schema is, on the other hand, flat to keep it simple. I also don't record `HiveConf`, since the object is around 100KB and dumping it with each query doesn't have much sense to me. I will research it later whether there is anything really useful for Assessment in that object