### PR TITLE
Move rollover time updates under DatePartitionedRecordsWriterFactory

### DIFF
--- a/src/java/com/google/cloud/bigquery/dwhassessment/hooks/logger/EventLogger.java
+++ b/src/java/com/google/cloud/bigquery/dwhassessment/hooks/logger/EventLogger.java
@@ -154,7 +154,7 @@ public class EventLogger {
     return null;
   }
 
-  private void handleTick() {
+  private synchronized void handleTick() {
     try {
       maybeRolloverWriterForDay();
     } catch (IOException e) {
@@ -174,7 +174,7 @@ public class EventLogger {
     }
   }
 
-  private void writeEventWithRetries(GenericRecord event) {
+  private synchronized void writeEventWithRetries(GenericRecord event) {
     for (int retryCount = 0; retryCount <= MAX_RETRIES; ++retryCount) {
       try {
         maybeRolloverWriterForDay();


### PR DESCRIPTION
Removes writerDate from EventLogger and moves it under the factory as rolloverTime of Instant type, calculated only once per day.

Also moves rollover time updates to the factory itself.