### PR TITLE
Use shorter unique IDs instead of UUID

### DIFF
--- a/WORKSPACE
+++ b/WORKSPACE
@@ -44,6 +44,12 @@ maven_install(
             neverlink = True,
         ),
         maven.artifact(
+            "commons-lang",
+            "commons-lang",
+            "2.6",
+            neverlink = True,
+        ),
+        maven.artifact(
             "org.apache.hadoop",
             "hadoop-common",
             "2.2.0",
@@ -109,6 +115,7 @@ maven_install(
         "org.apache.hive:hive-exec:2.2.0",
         "org.apache.tez:tez-api:0.8.5",
         "org.apache.tez:tez-common:0.8.5",
+        "commons-lang:commons-lang:2.6",
         "com.google.auto.value:auto-value:1.8.2",
         "com.google.auto.value:auto-value-annotations:1.8.2",
         "com.google.guava:guava:29.0-jre",

--- a/src/java/com/google/cloud/bigquery/dwhassessment/hooks/logger/DatePartitionedRecordsWriterFactory.java
+++ b/src/java/com/google/cloud/bigquery/dwhassessment/hooks/logger/DatePartitionedRecordsWriterFactory.java
@@ -23,7 +23,6 @@ import java.time.ZoneOffset;
 import java.time.format.DateTimeFormatter;
 import java.time.format.DateTimeParseException;
 import java.time.temporal.ChronoUnit;
-import java.util.UUID;
 import org.apache.avro.Schema;
 import org.apache.hadoop.conf.Configuration;
 import org.apache.hadoop.fs.FileSystem;
@@ -45,11 +44,11 @@ public class DatePartitionedRecordsWriterFactory {
   private final Schema schema;
   private final Clock clock;
   private Instant rolloverTime;
-  private final UUID loggerId;
+  private final String loggerId;
   private int logFileCount = 0;
 
   public DatePartitionedRecordsWriterFactory(
-      Path baseDir, Configuration conf, Schema schema, Clock clock, UUID loggerId)
+      Path baseDir, Configuration conf, Schema schema, Clock clock, String loggerId)
       throws IOException {
     this.conf = conf;
     this.createDirIfNotExists(baseDir);

--- a/src/java/com/google/cloud/bigquery/dwhassessment/hooks/logger/EventLogger.java
+++ b/src/java/com/google/cloud/bigquery/dwhassessment/hooks/logger/EventLogger.java
@@ -22,6 +22,7 @@ import static com.google.cloud.bigquery.dwhassessment.hooks.logger.LoggerVarsCon
 import static com.google.cloud.bigquery.dwhassessment.hooks.logger.LoggingHookConstants.QUERY_EVENT_SCHEMA;
 import static java.util.concurrent.TimeUnit.SECONDS;
 
+import com.google.cloud.bigquery.dwhassessment.hooks.logger.utils.IdGenerator;
 import java.time.Clock;
 import java.time.Duration;
 import java.util.Optional;
@@ -30,7 +31,6 @@ import org.apache.avro.generic.GenericRecord;
 import org.apache.commons.compress.utils.IOUtils;
 import com.google.common.util.concurrent.ThreadFactoryBuilder;
 import java.io.IOException;
-import java.util.UUID;
 import java.util.concurrent.ScheduledThreadPoolExecutor;
 import java.util.concurrent.ThreadFactory;
 import java.util.concurrent.TimeUnit;
@@ -60,7 +60,7 @@ public class EventLogger {
   private final EventRecordConstructor eventRecordConstructor;
   private final ScheduledThreadPoolExecutor logWriter;
   private final int queueCapacity;
-  private final UUID loggerId;
+  private final String loggerId;
 
   private RecordsWriter writer;
 
@@ -81,7 +81,7 @@ public class EventLogger {
 
   protected EventLogger(HiveConf conf, Clock clock) {
     eventRecordConstructor = new EventRecordConstructor(clock);
-    loggerId = UUID.randomUUID();
+    loggerId = IdGenerator.generate();
     queueCapacity =
         conf.getInt(
             HIVE_QUERY_EVENTS_QUEUE_CAPACITY.getConfName(), QUERY_EVENTS_QUEUE_DEFAULT_SIZE);

--- a/src/java/com/google/cloud/bigquery/dwhassessment/hooks/logger/utils/BUILD
+++ b/src/java/com/google/cloud/bigquery/dwhassessment/hooks/logger/utils/BUILD
@@ -1,4 +1,4 @@
-# Copyright 2022 Google LLC
+# Copyright 2022-2023 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -16,17 +16,9 @@ load("@rules_java//java:defs.bzl", "java_library")
 package(default_visibility = ["//src:internal"])
 
 java_library(
-    name = "logger",
+    name = "utils",
     srcs = glob(["*.java"]),
     deps = [
-        "//src/java/com/google/cloud/bigquery/dwhassessment/hooks/avro",
-        "//src/java/com/google/cloud/bigquery/dwhassessment/hooks/logger/utils",
-        "@maven//:com_google_guava_guava",
-        "@maven//:org_apache_avro_avro",
-        "@maven//:org_apache_commons_commons_compress",
-        "@maven//:org_apache_hadoop_hadoop_common",
-        "@maven//:org_apache_hive_hive_exec_2_2_0",
-        "@maven//:org_apache_tez_tez_api_0_8_5",
-        "@maven//:org_slf4j_slf4j_api",
+        "@maven//:commons_lang_commons_lang",
     ],
 )

--- a/src/java/com/google/cloud/bigquery/dwhassessment/hooks/logger/utils/IdGenerator.java
+++ b/src/java/com/google/cloud/bigquery/dwhassessment/hooks/logger/utils/IdGenerator.java
@@ -22,12 +22,9 @@ import org.apache.commons.lang.RandomStringUtils;
 public final class IdGenerator {
   private static final int ID_LENGTH = 10;
 
-  private static final String ALLOWED_CHARACTERS =
-      "0123456789ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz";
-
   private IdGenerator() {}
 
   public static String generate() {
-    return RandomStringUtils.random(ID_LENGTH, ALLOWED_CHARACTERS);
+    return RandomStringUtils.randomAlphanumeric(ID_LENGTH);
   }
 }

--- a/src/java/com/google/cloud/bigquery/dwhassessment/hooks/logger/utils/IdGenerator.java
+++ b/src/java/com/google/cloud/bigquery/dwhassessment/hooks/logger/utils/IdGenerator.java
@@ -1,0 +1,33 @@
+/*
+ * Copyright 2022-2023 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.google.cloud.bigquery.dwhassessment.hooks.logger.utils;
+
+import org.apache.commons.lang.RandomStringUtils;
+
+/** Unique id generator for the logger. */
+public final class IdGenerator {
+  private static final int ID_LENGTH = 10;
+
+  private static final String ALLOWED_CHARACTERS =
+      "0123456789ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz";
+
+  private IdGenerator() {}
+
+  public static String generate() {
+    return RandomStringUtils.random(ID_LENGTH, ALLOWED_CHARACTERS);
+  }
+}

--- a/src/javatests/com/google/cloud/bigquery/dwhassessment/hooks/logger/DatePartitionedRecordsWriterFactoryTest.java
+++ b/src/javatests/com/google/cloud/bigquery/dwhassessment/hooks/logger/DatePartitionedRecordsWriterFactoryTest.java
@@ -46,7 +46,7 @@ public class DatePartitionedRecordsWriterFactoryTest {
 
   @Rule public TemporaryFolder folder = new TemporaryFolder();
 
-  private static final String TEST_UUID = "a665f132-0606-4602-855d-04cd8a747f55";
+  private static final String TEST_ID = "a665f132";
 
   private HiveConf conf;
   private String tmpFolder;
@@ -66,7 +66,7 @@ public class DatePartitionedRecordsWriterFactoryTest {
 
     // Act
     new DatePartitionedRecordsWriterFactory(
-        targetDirectoryPath, conf, QUERY_EVENT_SCHEMA, fixedClock, UUID.randomUUID());
+        targetDirectoryPath, conf, QUERY_EVENT_SCHEMA, fixedClock, TEST_ID);
 
     // Assert
     assertThat(fs.exists(targetDirectoryPath)).isTrue();
@@ -91,7 +91,7 @@ public class DatePartitionedRecordsWriterFactoryTest {
         .isEqualTo(
             new Path(
                 targetDirectoryPath.getFileSystem(conf).resolvePath(targetDirectoryPath),
-                "dwhassessment_" + TEST_UUID + "_1.avro"));
+                "dwhassessment_" + TEST_ID + "_1.avro"));
     assertThat(fs.exists(targetDirectoryPath)).isTrue();
     assertThat(existedBefore).isFalse();
   }
@@ -108,9 +108,9 @@ public class DatePartitionedRecordsWriterFactoryTest {
     RecordsWriter writer3 = datePartitionedRecordsWriterFactory.createWriter();
 
     // Assert
-    assertThat(writer1.getPath().getName()).isEqualTo("dwhassessment_" + TEST_UUID + "_1.avro");
-    assertThat(writer2.getPath().getName()).isEqualTo("dwhassessment_" + TEST_UUID + "_2.avro");
-    assertThat(writer3.getPath().getName()).isEqualTo("dwhassessment_" + TEST_UUID + "_3.avro");
+    assertThat(writer1.getPath().getName()).isEqualTo("dwhassessment_" + TEST_ID + "_1.avro");
+    assertThat(writer2.getPath().getName()).isEqualTo("dwhassessment_" + TEST_ID + "_2.avro");
+    assertThat(writer3.getPath().getName()).isEqualTo("dwhassessment_" + TEST_ID + "_3.avro");
   }
 
   @Test
@@ -131,10 +131,10 @@ public class DatePartitionedRecordsWriterFactoryTest {
     RecordsWriter writer3 = datePartitionedRecordsWriterFactory.createWriter();
 
     // Assert
-    assertThat(writer1.getPath().getName()).isEqualTo("dwhassessment_" + TEST_UUID + "_1.avro");
-    assertThat(writer2.getPath().getName()).isEqualTo("dwhassessment_" + TEST_UUID + "_2.avro");
+    assertThat(writer1.getPath().getName()).isEqualTo("dwhassessment_" + TEST_ID + "_1.avro");
+    assertThat(writer2.getPath().getName()).isEqualTo("dwhassessment_" + TEST_ID + "_2.avro");
     assertThat(writer2.getPath().getParent().getName()).isEqualTo("2022-12-25");
-    assertThat(writer3.getPath().getName()).isEqualTo("dwhassessment_" + TEST_UUID + "_1.avro");
+    assertThat(writer3.getPath().getName()).isEqualTo("dwhassessment_" + TEST_ID + "_1.avro");
     assertThat(writer3.getPath().getParent().getName()).isEqualTo("2022-12-26");
   }
 
@@ -240,7 +240,7 @@ public class DatePartitionedRecordsWriterFactoryTest {
   private DatePartitionedRecordsWriterFactory createRecordsWriterFactory(Clock clock)
       throws IOException {
     return new DatePartitionedRecordsWriterFactory(
-        new Path(tmpFolder), conf, QUERY_EVENT_SCHEMA, clock, UUID.fromString(TEST_UUID));
+        new Path(tmpFolder), conf, QUERY_EVENT_SCHEMA, clock, TEST_ID);
   }
 
   private Instant parseDateTime(String dateTimeString) {

--- a/src/javatests/com/google/cloud/bigquery/dwhassessment/hooks/logger/utils/BUILD
+++ b/src/javatests/com/google/cloud/bigquery/dwhassessment/hooks/logger/utils/BUILD
@@ -1,4 +1,4 @@
-# Copyright 2022 Google LLC
+# Copyright 2022-2023 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -11,22 +11,25 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-load("@rules_java//java:defs.bzl", "java_library")
-
-package(default_visibility = ["//src:internal"])
+load("@rules_java//java:defs.bzl", "java_library", "java_test")
 
 java_library(
-    name = "logger",
+    name = "tests",
+    testonly = 1,
     srcs = glob(["*.java"]),
     deps = [
-        "//src/java/com/google/cloud/bigquery/dwhassessment/hooks/avro",
         "//src/java/com/google/cloud/bigquery/dwhassessment/hooks/logger/utils",
-        "@maven//:com_google_guava_guava",
-        "@maven//:org_apache_avro_avro",
-        "@maven//:org_apache_commons_commons_compress",
-        "@maven//:org_apache_hadoop_hadoop_common",
-        "@maven//:org_apache_hive_hive_exec_2_2_0",
-        "@maven//:org_apache_tez_tez_api_0_8_5",
-        "@maven//:org_slf4j_slf4j_api",
+        "@maven_tests//:com_google_truth_truth",
+        "@maven_tests//:commons_lang_commons_lang",
+        "@maven_tests//:junit_junit",
+    ],
+)
+
+java_test(
+    name = "IdGeneratorTest",
+    size = "small",
+    test_class = "com.google.cloud.bigquery.dwhassessment.hooks.logger.utils.IdGeneratorTest",
+    runtime_deps = [
+        ":tests",
     ],
 )

--- a/src/javatests/com/google/cloud/bigquery/dwhassessment/hooks/logger/utils/IdGeneratorTest.java
+++ b/src/javatests/com/google/cloud/bigquery/dwhassessment/hooks/logger/utils/IdGeneratorTest.java
@@ -1,0 +1,33 @@
+/*
+ * Copyright 2022-2023 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.google.cloud.bigquery.dwhassessment.hooks.logger.utils;
+
+import static com.google.common.truth.Truth.assertThat;
+
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.junit.runners.JUnit4;
+
+@RunWith(JUnit4.class)
+public class IdGeneratorTest {
+  @Test
+  public void generate_idHasExpectedLength() {
+    String id = IdGenerator.generate();
+
+    assertThat(id).hasLength(10);
+  }
+}


### PR DESCRIPTION
UUID is long and using it for logger IDs is a bit overkill. Shorter unique IDs with 10 characters will be enough for dumping logs, even if customer environment creates a lot of unique sessions (also in case of multiple short-lived sessions collision could happen only within one directory).