### PR TITLE
Shorten default rollover period and make it configurable

### DIFF
--- a/src/java/com/google/cloud/bigquery/dwhassessment/hooks/logger/BUILD
+++ b/src/java/com/google/cloud/bigquery/dwhassessment/hooks/logger/BUILD
@@ -22,6 +22,7 @@ java_library(
         "//src/java/com/google/cloud/bigquery/dwhassessment/hooks/avro",
         "//src/java/com/google/cloud/bigquery/dwhassessment/hooks/logger/utils",
         "@maven//:com_google_guava_guava",
+        "@maven//:commons_lang_commons_lang",
         "@maven//:org_apache_avro_avro",
         "@maven//:org_apache_commons_commons_compress",
         "@maven//:org_apache_hadoop_hadoop_common",

--- a/src/java/com/google/cloud/bigquery/dwhassessment/hooks/logger/DatePartitionedRecordsWriterFactory.java
+++ b/src/java/com/google/cloud/bigquery/dwhassessment/hooks/logger/DatePartitionedRecordsWriterFactory.java
@@ -70,7 +70,12 @@ public class DatePartitionedRecordsWriterFactory {
   private final Duration rolloverInterval;
 
   public DatePartitionedRecordsWriterFactory(
-      Path baseDir, Configuration conf, Schema schema, Clock clock, String loggerId, Duration rolloverInterval)
+      Path baseDir,
+      Configuration conf,
+      Schema schema,
+      Clock clock,
+      String loggerId,
+      Duration rolloverInterval)
       throws IOException {
     this.conf = conf;
     this.createDirIfNotExists(baseDir);
@@ -140,7 +145,10 @@ public class DatePartitionedRecordsWriterFactory {
     return ISO_LOCAL_DATE.format(date);
   }
 
-  /** Next rollover time is 30 minutes after or at the beginning of the next day, depending on what will happen earlier. */
+  /**
+   * Next rollover time is at next configured interval or at the beginning of the next day,
+   * depending on what will happen earlier.
+   */
   private Instant calculateNextRolloverTime() {
     Instant currentInstant = clock.instant();
     Instant nextRollover = currentInstant.plus(rolloverInterval).truncatedTo(ChronoUnit.MINUTES);

--- a/src/java/com/google/cloud/bigquery/dwhassessment/hooks/logger/DatePartitionedRecordsWriterFactory.java
+++ b/src/java/com/google/cloud/bigquery/dwhassessment/hooks/logger/DatePartitionedRecordsWriterFactory.java
@@ -16,6 +16,7 @@
 package com.google.cloud.bigquery.dwhassessment.hooks.logger;
 
 import static java.time.format.DateTimeFormatter.ISO_LOCAL_DATE;
+import static java.time.format.DateTimeFormatter.ISO_LOCAL_DATE_TIME;
 import static java.time.temporal.ChronoField.HOUR_OF_DAY;
 import static java.time.temporal.ChronoField.MINUTE_OF_HOUR;
 import static java.time.temporal.ChronoField.NANO_OF_SECOND;
@@ -119,6 +120,12 @@ public class DatePartitionedRecordsWriterFactory {
     }
 
     rolloverTime = calculateNextRolloverTime();
+
+    LOG.info(
+        "Rolling over file for logger ID '{}'. Next rollover is expected at '{}'",
+        loggerId,
+        ISO_LOCAL_DATE_TIME.format(rolloverTime.atOffset(ZoneOffset.UTC)));
+
     return true;
   }
 

--- a/src/java/com/google/cloud/bigquery/dwhassessment/hooks/logger/DatePartitionedRecordsWriterFactory.java
+++ b/src/java/com/google/cloud/bigquery/dwhassessment/hooks/logger/DatePartitionedRecordsWriterFactory.java
@@ -21,6 +21,7 @@ import static java.time.temporal.ChronoField.HOUR_OF_DAY;
 import static java.time.temporal.ChronoField.MINUTE_OF_HOUR;
 import static java.time.temporal.ChronoField.NANO_OF_SECOND;
 import static java.time.temporal.ChronoField.SECOND_OF_MINUTE;
+import static org.apache.commons.lang.ObjectUtils.min;
 
 import java.io.IOException;
 import java.time.Clock;
@@ -33,6 +34,7 @@ import java.time.format.DateTimeFormatterBuilder;
 import java.time.format.DateTimeParseException;
 import java.time.temporal.ChronoUnit;
 import org.apache.avro.Schema;
+import org.apache.commons.lang.ObjectUtils;
 import org.apache.hadoop.conf.Configuration;
 import org.apache.hadoop.fs.FileSystem;
 import org.apache.hadoop.fs.Path;
@@ -161,7 +163,7 @@ public class DatePartitionedRecordsWriterFactory {
     Instant nextRollover = currentInstant.plus(rolloverInterval).truncatedTo(ChronoUnit.MINUTES);
     Instant nextDay = currentInstant.plus(1, ChronoUnit.DAYS).truncatedTo(ChronoUnit.DAYS);
 
-    return nextDay.isAfter(nextRollover) ? nextRollover : nextDay;
+    return (Instant) min(nextRollover, nextDay);
   }
 
   private LocalDate getCurrentDate() {

--- a/src/java/com/google/cloud/bigquery/dwhassessment/hooks/logger/LoggerVarsConfig.java
+++ b/src/java/com/google/cloud/bigquery/dwhassessment/hooks/logger/LoggerVarsConfig.java
@@ -28,9 +28,16 @@ public enum LoggerVarsConfig {
   HIVE_QUERY_EVENTS_BASE_PATH(
       "dwhassessment.hook.base-directory",
       "Base directory for query event messages written by Migration Assessment hook."),
-  HIVE_QUERY_EVENTS_ROLLOVER_CHECK_INTERVAL(
+
+  HIVE_QUERY_EVENTS_ROLLOVER_INTERVAL(
       "dwhassessment.hook.rollover-interval",
-      "Frequency at which the file rollover check is triggered, e.g. 600s.");
+      "Frequency at which the file rollover should be performed, e.g. 600s. On day change rollover"
+          + " happens always."),
+
+  HIVE_QUERY_EVENTS_ROLLOVER_ELIGIBILITY_CHECK_INTERVAL(
+      "dwhassessment.hook.rollover-eligibility-check-interval",
+      "Frequency at which the file rollover eligibility check is triggered in the background, e.g."
+          + " 600s.");
 
   private final String confName;
   private final String description;


### PR DESCRIPTION
Rollover once in a day has several drawbacks:

* It makes debugging harder, as it requires to reload remote hive-server2 every time when we want to dump pending records
* If there is an intermittent failure during closure, logs for 24 hours are lost
* It can lead to big files

This makes the rollover interval configurable and sets it to every 10 minutes by default. One problem with that is that there will be empty files for intervals when cluster is idle. I have a task for and it will be handled in a separate PR.