### PR TITLE
Dump Hive server version

### DIFF
--- a/src/java/com/google/cloud/bigquery/dwhassessment/hooks/avro/QueryEvents.avsc
+++ b/src/java/com/google/cloud/bigquery/dwhassessment/hooks/avro/QueryEvents.avsc
@@ -189,6 +189,14 @@
       "default": null
     },
     {
+      "name": "HiveVersion",
+      "type": [
+        "null",
+        "string"
+      ],
+      "default": null
+    },
+    {
       "name": "ClientIpAddress",
       "type": [
         "null",

--- a/src/java/com/google/cloud/bigquery/dwhassessment/hooks/logger/EventRecordConstructor.java
+++ b/src/java/com/google/cloud/bigquery/dwhassessment/hooks/logger/EventRecordConstructor.java
@@ -50,6 +50,7 @@ import org.apache.hadoop.hive.ql.log.PerfLogger;
 import org.apache.hadoop.hive.ql.session.SessionState;
 import org.apache.hadoop.mapred.Counters;
 import org.apache.hadoop.mapred.Counters.Group;
+import org.apache.hive.common.util.HiveVersionInfo;
 import org.apache.tez.common.counters.CounterGroup;
 import org.apache.tez.common.counters.TezCounter;
 import org.apache.tez.common.counters.TezCounters;
@@ -110,6 +111,7 @@ public class EventRecordConstructor {
         .set("ClientIpAddress", hookContext.getIpAddress())
         .set("ClientIpAddress", hookContext.getIpAddress())
         .set("HookVersion", HOOK_VERSION)
+        .set("HiveVersion", HiveVersionInfo.getVersion())
         .set("HiveAddress", getHiveInstanceAddress(hookContext))
         .set("HiveInstanceType", getHiveInstanceType(hookContext))
         .set("LlapApplicationId", determineLlapId(conf, executionMode))

--- a/src/java/com/google/cloud/bigquery/dwhassessment/hooks/testing/TestUtils.java
+++ b/src/java/com/google/cloud/bigquery/dwhassessment/hooks/testing/TestUtils.java
@@ -114,6 +114,7 @@ public final class TestUtils {
         .set("InvokerInfo", "test_session_id")
         .set("ThreadName", "test_thread_id")
         .set("HookVersion", "1.0")
+        .set("HiveVersion", "2.2.0")
         .set("ClientIpAddress", "192.168.10.10")
         .set("HiveAddress", "hive_addr")
         .set("HiveInstanceType", "HS2")


### PR DESCRIPTION
Version Stored in metastore.VERSION table is not accurate (e.g. in the example below the actual version is 2.3.6):

```
mysql> select * from VERSION;
+--------+----------------+----------------------------+
| VER_ID | SCHEMA_VERSION | VERSION_COMMENT            |
+--------+----------------+----------------------------+
|      1 | 2.3.0          | Hive release version 2.3.0 |
+--------+----------------+----------------------------+
```

Thrift also doesn't provide an access to Hive version. Generally, we need such information only once, but logging in with the query event is simple and cheap and potentially can be useful for presentation (for cases where customer has different version of the cluster using the same metastore – different version mean additional maintenance costs).