### PR TITLE
Handle disabled logging gracefully

### DIFF
--- a/src/java/com/google/cloud/bigquery/dwhassessment/hooks/BUILD
+++ b/src/java/com/google/cloud/bigquery/dwhassessment/hooks/BUILD
@@ -21,6 +21,7 @@ java_library(
     deps = [
         "//src/java/com/google/cloud/bigquery/dwhassessment/hooks/avro",
         "//src/java/com/google/cloud/bigquery/dwhassessment/hooks/logger",
+        "//src/java/com/google/cloud/bigquery/dwhassessment/hooks/logger/utils",
         "@maven//:org_apache_hadoop_hadoop_mapred_0_22_0",
         "@maven//:org_apache_hive_hive_exec_2_2_0",
         "@maven//:org_slf4j_slf4j_api",

--- a/src/java/com/google/cloud/bigquery/dwhassessment/hooks/MigrationAssessmentLoggingHook.java
+++ b/src/java/com/google/cloud/bigquery/dwhassessment/hooks/MigrationAssessmentLoggingHook.java
@@ -16,10 +16,12 @@
 package com.google.cloud.bigquery.dwhassessment.hooks;
 
 import com.google.cloud.bigquery.dwhassessment.hooks.logger.EventLogger;
+import com.google.cloud.bigquery.dwhassessment.hooks.logger.utils.VersionValidator;
 import java.time.Clock;
 import org.apache.avro.generic.GenericRecord;
 import org.apache.hadoop.hive.ql.hooks.ExecuteWithHookContext;
 import org.apache.hadoop.hive.ql.hooks.HookContext;
+import org.apache.hive.common.util.HiveVersionInfo;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -28,7 +30,17 @@ public class MigrationAssessmentLoggingHook implements ExecuteWithHookContext {
 
   private static final Logger LOG = LoggerFactory.getLogger(MigrationAssessmentLoggingHook.class);
 
+  private static final String version = VersionValidator.getHiveVersion();
+
   public void run(HookContext hookContext) throws Exception {
+    if (!VersionValidator.isHiveVersionSupported(version)) {
+      LOG.error(
+          "Current Hive version '{}' is not supported by the Assessment logging hook, logging"
+              + " disabled. Please refer to the documentation.",
+          version);
+      return;
+    }
+
     try {
       EventLogger logger = EventLogger.getInstance(hookContext.getConf(), Clock.systemUTC());
       logger.handle(hookContext);

--- a/src/java/com/google/cloud/bigquery/dwhassessment/hooks/logger/utils/VersionValidator.java
+++ b/src/java/com/google/cloud/bigquery/dwhassessment/hooks/logger/utils/VersionValidator.java
@@ -51,16 +51,7 @@ public class VersionValidator {
     int minor = Integer.parseInt(matcher.group(2));
 
     // Covers v2.2.x-v3.x.x
-    boolean isVersionValid = major == 2 ? minor >= 2 : major == 3;
-
-    if (!isVersionValid) {
-      LOG.error(
-          "Current Hive version '{}' is not supported by the Assessment logging hook, logging"
-              + " disabled. Please refer to the documentation.",
-          version);
-    }
-
-    return isVersionValid;
+    return major == 2 ? minor >= 2 : major == 3;
   }
 
   private VersionValidator() {}


### PR DESCRIPTION
This fixes several NullPointer exceptions happening due to hook misconfiguration or Hive unsupported version.