### PR TITLE
dump yarn resource usage information

### DIFF
--- a/src/java/com/google/cloud/bigquery/dwhassessment/hooks/avro/QueryEvents.avsc
+++ b/src/java/com/google/cloud/bigquery/dwhassessment/hooks/avro/QueryEvents.avsc
@@ -283,6 +283,220 @@
         "string"
       ],
       "default": null
+    },
+    {
+      "name": "YarnProcess",
+      "type": [
+        "null",
+        "float"
+      ],
+      "default": null
+    },
+    {
+      "name": "YarnApplicationType",
+      "type": [
+        "null",
+        "string"
+      ],
+      "default": null
+    },
+    {
+      "name": "YarnApplicationState",
+      "type": [
+        "null",
+        "string"
+      ],
+      "default": null
+    },
+    {
+      "name": "YarnDiagnostics",
+      "type": [
+        "null",
+        "string"
+      ],
+      "default": null
+    },
+    {
+      "name": "YarnCurrentApplicationAttemptId",
+      "type": [
+        "null",
+        "string"
+      ],
+      "default": null
+    },
+    {
+      "name": "YarnUser",
+      "type": [
+        "null",
+        "string"
+      ],
+      "default": null
+    },
+    {
+      "name": "YarnStartTime",
+      "type": [
+        "null",
+        {
+          "type": "long",
+          "logicalType": "timestamp-millis"
+        }
+      ],
+      "default": null
+    },
+    {
+      "name": "YarnFinishTime",
+      "type": [
+        "null",
+        {
+          "type": "long",
+          "logicalType": "timestamp-millis"
+        }
+      ],
+      "default": null
+    },
+    {
+      "name": "YarnFinalApplicationStatus",
+      "type": [
+        "null",
+        "string"
+      ],
+      "default": null
+    },
+    {
+      "name": "YarnReportNumUsedContainers",
+      "type": [
+        "null",
+        "int"
+      ],
+      "default": null
+    },
+    {
+      "name": "YarnReportNumReservedContainers",
+      "type": [
+        "null",
+        "int"
+      ],
+      "default": null
+    },
+    {
+      "name": "YarnReportUsedResources",
+      "type": [
+        "null",
+        "string"
+      ],
+      "default": null
+    },
+    {
+      "name": "YarnReportUsedResourcesMemory",
+      "type": [
+        "null",
+        "long"
+      ],
+      "default": null
+    },
+    {
+      "name": "YarnReportUsedResourcesVcore",
+      "type": [
+        "null",
+        "int"
+      ],
+      "default": null
+    },
+    {
+      "name": "YarnReportReservedResources",
+      "type": [
+        "null",
+        "string"
+      ],
+      "default": null
+    },
+    {
+      "name": "YarnReportReservedResourcesMemory",
+      "type": [
+        "null",
+        "long"
+      ],
+      "default": null
+    },
+    {
+      "name": "YarnReportReservedResourcesVcore",
+      "type": [
+        "null",
+        "int"
+      ],
+      "default": null
+    },
+    {
+      "name": "YarnReportNeededResources",
+      "type": [
+        "null",
+        "string"
+      ],
+      "default": null
+    },
+    {
+      "name": "YarnReportNeededResourcesMemory",
+      "type": [
+        "null",
+        "long"
+      ],
+      "default": null
+    },
+    {
+      "name": "YarnReportNeededResourcesVcore",
+      "type": [
+        "null",
+        "int"
+      ],
+      "default": null
+    },
+    {
+      "name": "YarnReportMemorySeconds",
+      "type": [
+        "null",
+        "long"
+      ],
+      "default": null
+    },
+    {
+      "name": "YarnReportVcoreSeconds",
+      "type": [
+        "null",
+        "long"
+      ],
+      "default": null
+    },
+    {
+      "name": "YarnReportQueueUsagePercentage",
+      "type": [
+        "null",
+        "float"
+      ],
+      "default": null
+    },
+    {
+      "name": "YarnReportClusterUsagePercentage",
+      "type": [
+        "null",
+        "float"
+      ],
+      "default": null
+    },
+    {
+      "name": "YarnReportPreemptedMemorySeconds",
+      "type": [
+        "null",
+        "long"
+      ],
+      "default": null
+    },
+    {
+      "name": "YarnReportPreemptedVcoreSeconds",
+      "type": [
+        "null",
+        "long"
+      ],
+      "default": null
     }
   ]
 }

--- a/src/java/com/google/cloud/bigquery/dwhassessment/hooks/logger/EventRecordConstructor.java
+++ b/src/java/com/google/cloud/bigquery/dwhassessment/hooks/logger/EventRecordConstructor.java
@@ -157,15 +157,23 @@ public class EventRecordConstructor {
                         recordBuilder.set("HiveHostName", applicationReport.getHost());
                         recordBuilder.set("Queue", applicationReport.getQueue());
                         recordBuilder.set("YarnProcess", applicationReport.getProgress());
-                        recordBuilder.set("YarnApplicationType", applicationReport.getApplicationType());
-                        recordBuilder.set("YarnApplicationState", applicationReport.getYarnApplicationState().toString());
+                        recordBuilder.set(
+                            "YarnApplicationType", applicationReport.getApplicationType());
+                        recordBuilder.set(
+                            "YarnApplicationState",
+                            applicationReport.getYarnApplicationState().toString());
                         recordBuilder.set("YarnDiagnostics", applicationReport.getDiagnostics());
-                        recordBuilder.set("YarnCurrentApplicationAttemptId", applicationReport.getCurrentApplicationAttemptId().toString());
+                        recordBuilder.set(
+                            "YarnCurrentApplicationAttemptId",
+                            applicationReport.getCurrentApplicationAttemptId().toString());
                         recordBuilder.set("YarnUser", applicationReport.getUser());
                         recordBuilder.set("YarnStartTime", applicationReport.getStartTime());
                         recordBuilder.set("YarnFinishTime", applicationReport.getFinishTime());
-                        recordBuilder.set("YarnFinalApplicationStatus", applicationReport.getFinalApplicationStatus().toString());
-                        retrieveApplicationResourceUsageReport(recordBuilder, applicationReport.getApplicationResourceUsageReport());
+                        recordBuilder.set(
+                            "YarnFinalApplicationStatus",
+                            applicationReport.getFinalApplicationStatus().toString());
+                        retrieveApplicationResourceUsageReport(
+                            recordBuilder, applicationReport.getApplicationResourceUsageReport());
                       });
             });
 
@@ -177,36 +185,87 @@ public class EventRecordConstructor {
     return recordBuilder.build();
   }
 
-  private void retrieveApplicationResourceUsageReport(GenericRecordBuilder recordBuilder, ApplicationResourceUsageReport applicationResourceUsageReport) {
+  private void retrieveApplicationResourceUsageReport(
+      GenericRecordBuilder recordBuilder,
+      ApplicationResourceUsageReport applicationResourceUsageReport) {
     String reportClassName = "org.apache.hadoop.yarn.api.records.ApplicationResourceUsageReport";
     String resourceClassName = "org.apache.hadoop.yarn.api.records.Resource";
 
-    ImmutableMap<String, String> reportMethods = ImmutableMap.<String, String>builder()
-        .put("getNumUsedContainers", "YarnReportNumUsedContainers")
-        .put("getNumReservedContainers", "YarnReportNumReservedContainers")
-        .put("getMemorySeconds", "YarnReportMemorySeconds")
-        .put("getVcoreSeconds", "YarnReportVcoreSeconds")
-        .put("getQueueUsagePercentage", "YarnReportQueueUsagePercentage")
-        .put("getClusterUsagePercentage", "YarnReportClusterUsagePercentage")
-        .put("getPreemptedMemorySeconds", "YarnReportPreemptedMemorySeconds")
-        .put("getPreemptedVcoreSeconds", "YarnReportPreemptedVcoreSeconds")
-        .build();
+    ImmutableMap<String, String> reportMethods =
+        ImmutableMap.<String, String>builder()
+            .put("getNumUsedContainers", "YarnReportNumUsedContainers")
+            .put("getNumReservedContainers", "YarnReportNumReservedContainers")
+            .put("getMemorySeconds", "YarnReportMemorySeconds")
+            .put("getVcoreSeconds", "YarnReportVcoreSeconds")
+            .put("getQueueUsagePercentage", "YarnReportQueueUsagePercentage")
+            .put("getClusterUsagePercentage", "YarnReportClusterUsagePercentage")
+            .put("getPreemptedMemorySeconds", "YarnReportPreemptedMemorySeconds")
+            .put("getPreemptedVcoreSeconds", "YarnReportPreemptedVcoreSeconds")
+            .build();
 
-    reportMethods.forEach((methodName, fieldName) -> callMethodWithReflection(methodName, fieldName, recordBuilder, applicationResourceUsageReport, reportClassName));
-    recordBuilder.set("YarnReportUsedResources", String.valueOf(applicationResourceUsageReport.getUsedResources().toString()));
-    callMethodWithReflection("getMemorySize", "YarnReportUsedResourcesMemory", recordBuilder, applicationResourceUsageReport.getUsedResources(), resourceClassName);
-    callMethodWithReflection("getVirtualCores", "YarnReportUsedResourcesVcore", recordBuilder, applicationResourceUsageReport.getUsedResources(), resourceClassName);
+    reportMethods.forEach(
+        (methodName, fieldName) ->
+            callMethodWithReflection(
+                methodName,
+                fieldName,
+                recordBuilder,
+                applicationResourceUsageReport,
+                reportClassName));
+    recordBuilder.set(
+        "YarnReportUsedResources",
+        String.valueOf(applicationResourceUsageReport.getUsedResources().toString()));
+    callMethodWithReflection(
+        "getMemorySize",
+        "YarnReportUsedResourcesMemory",
+        recordBuilder,
+        applicationResourceUsageReport.getUsedResources(),
+        resourceClassName);
+    callMethodWithReflection(
+        "getVirtualCores",
+        "YarnReportUsedResourcesVcore",
+        recordBuilder,
+        applicationResourceUsageReport.getUsedResources(),
+        resourceClassName);
 
-    recordBuilder.set("YarnReportReservedResources", String.valueOf(applicationResourceUsageReport.getReservedResources().toString()));
-    callMethodWithReflection("getMemorySize", "YarnReportReservedResourcesMemory", recordBuilder, applicationResourceUsageReport.getReservedResources(), resourceClassName);
-    callMethodWithReflection("getVirtualCores", "YarnReportReservedResourcesVcore", recordBuilder, applicationResourceUsageReport.getReservedResources(), resourceClassName);
+    recordBuilder.set(
+        "YarnReportReservedResources",
+        String.valueOf(applicationResourceUsageReport.getReservedResources().toString()));
+    callMethodWithReflection(
+        "getMemorySize",
+        "YarnReportReservedResourcesMemory",
+        recordBuilder,
+        applicationResourceUsageReport.getReservedResources(),
+        resourceClassName);
+    callMethodWithReflection(
+        "getVirtualCores",
+        "YarnReportReservedResourcesVcore",
+        recordBuilder,
+        applicationResourceUsageReport.getReservedResources(),
+        resourceClassName);
 
-    recordBuilder.set("YarnReportNeededResources", String.valueOf(applicationResourceUsageReport.getNeededResources().toString()));
-    callMethodWithReflection("getMemorySize", "YarnReportNeededResourcesMemory", recordBuilder, applicationResourceUsageReport.getNeededResources(), resourceClassName);
-    callMethodWithReflection("getVirtualCores", "YarnReportNeededResourcesVcore", recordBuilder, applicationResourceUsageReport.getNeededResources(), resourceClassName);
+    recordBuilder.set(
+        "YarnReportNeededResources",
+        String.valueOf(applicationResourceUsageReport.getNeededResources().toString()));
+    callMethodWithReflection(
+        "getMemorySize",
+        "YarnReportNeededResourcesMemory",
+        recordBuilder,
+        applicationResourceUsageReport.getNeededResources(),
+        resourceClassName);
+    callMethodWithReflection(
+        "getVirtualCores",
+        "YarnReportNeededResourcesVcore",
+        recordBuilder,
+        applicationResourceUsageReport.getNeededResources(),
+        resourceClassName);
   }
 
-  private void callMethodWithReflection(String methodName, String fieldNameInAvro, GenericRecordBuilder recordBuilder, Object object, String className) {
+  private void callMethodWithReflection(
+      String methodName,
+      String fieldNameInAvro,
+      GenericRecordBuilder recordBuilder,
+      Object object,
+      String className) {
     try {
       Method method = Class.forName(className).getMethod(methodName);
       recordBuilder.set(fieldNameInAvro, method.invoke(object));


### PR DESCRIPTION
We want to retrieve yarn resource information from yarn api using applicationId when postHook event is received.
Methods are called using reflection in case if customers have hive version that does not support needed methods for retrieving usage data.