### PR TITLE
Add scripts for manual release

### DIFF
--- a/scripts/release/build.sh
+++ b/scripts/release/build.sh
@@ -27,10 +27,10 @@
 set -e
 
 #Variables
-export SCRIPT_WORKING_DIR="${pwd}"
-export SCRIPT_DIR="$(dirname "$0")"
+export SCRIPT=$(realpath "$0")
+export SCRIPT_DIR=$(dirname "$SCRIPT")
 export SCRIPT_PARENT_DIR="$(dirname -- "$SCRIPT_DIR")"
-export REPO_DIR="$(dirname -- "SCRIPT_PARENT_DIR")"
+export REPO_DIR="$(dirname -- "$SCRIPT_PARENT_DIR")"
 
 cd "${REPO_DIR}"
 

--- a/scripts/release/build.sh
+++ b/scripts/release/build.sh
@@ -1,0 +1,41 @@
+#!/bin/bash
+#
+# Copyright 2023 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+# Display commands being run.
+# WARNING: please only enable 'set -x' if necessary for debugging, and be very
+#  careful if you handle credentials (e.g. from Keystore) with 'set -x':
+#  statements like "export VAR=$(cat /tmp/keystore/credentials)" will result in
+#  the credentials being printed in build logs.
+#  Additionally, recursive invocation with credentials as command-line
+#  parameters, will print the full command, with credentials, in the build logs.
+# set -x
+
+# Fail on any error.
+set -e
+
+#Variables
+export SCRIPT_WORKING_DIR="${pwd}"
+export SCRIPT_DIR="$(dirname "$0")"
+export SCRIPT_PARENT_DIR="$(dirname -- "$SCRIPT_DIR")"
+export REPO_DIR="$(dirname -- "SCRIPT_PARENT_DIR")"
+
+cd "${REPO_DIR}"
+
+#Test everything
+bazel test //...
+
+#Build extraction tool
+bazel build dist:all

--- a/scripts/release/release.sh
+++ b/scripts/release/release.sh
@@ -1,0 +1,132 @@
+#!/bin/bash
+# Copyright 2023 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License
+#
+# A manual build script to build release and update github repo
+#
+# Display commands being run.
+# WARNING: please only enable 'set -x' if necessary for debugging, and be very
+#  careful if you handle credentials (e.g. from Keystore) with 'set -x':
+#  statements like "export VAR=$(cat /tmp/keystore/credentials)" will result in
+#  the credentials being printed in build logs.
+#  Additionally, recursive invocation with credentials as command-line
+#  parameters, will print the full command, with credentials, in the build logs.
+# set -x
+
+# Fail on any error.
+set -e
+# Fail on errors in pipes.
+set -o pipefail
+
+echo Enter client id:
+read -s -r GIT_CLIENT_ID
+echo Enter token:
+read -s -r GIT_CLIENT_TOKEN
+
+#Variables
+export SCRIPT_WORKING_DIR="${pwd}"
+export RELEASE_SCRIPT_DIR="$(dirname "$0")"
+export SCRIPT_PARENT_DIR="$(dirname -- "$RELEASE_SCRIPT_DIR")"
+export REPO_DIR="$(dirname -- "$SCRIPT_PARENT_DIR")"
+export RELEASE_OUTPUT_FILE="${REPO_DIR}/bazel-bin/dist/hadoop-migration-assessment-hooks.zip"
+export BUILD_SCRIPT="$RELEASE_SCRIPT_DIR/build.sh"
+source "${RELEASE_SCRIPT_DIR}/release_utils.sh"
+
+cd "${REPO_DIR}"
+
+export LAST_GIT_TAG="$(git tag |
+  grep -E '^v[0-9]' |
+  sort -V |
+  tail -1)"
+
+use_existing_tag=false
+
+# Do we already know what version we want to release?
+if [[ -z "${USE_TAG}" ]]; then
+  if [[ -z "${LAST_GIT_TAG}" ]]; then
+    err "No previous git tag found and it was not provided with USE_TAG env"
+  fi
+  VERSION="$(increment_tag_version ${LAST_GIT_TAG})"
+  log "Will create new version ${VERSION}"
+
+  if [ "$(git tag -l ${VERSION})" ]; then
+    err "ERROR! Tag for ${VERSION} already exists!"
+  fi
+
+  code="$(http_get_error_code "Accept: application/vnd.github.v3+json" \
+    "https://api.github.com/repos/google/hadoop-migration-assessment-tools/releases/tags/${VERSION}")"
+  if [ "${code}" != "404" ]; then
+    err "ERROR! Release with ${VERSION} tag version name already exists or http failed! Http code is ${code}"
+  fi
+else
+  VERSION="${USE_TAG}"
+  if [[ "${LAST_RELEASE_TAG}" ]]; then
+    LAST_GIT_TAG=${LAST_RELEASE_TAG}
+  fi
+  use_existing_tag=true
+  git checkout tags/"${VERSION}" -b "${VERSION}-release"
+fi
+
+log "Version name ${VERSION} verified"
+
+# Run build and integration tests
+cd "${SCRIPT_WORKING_DIR}"
+log "Build script : ${BUILD_SCRIPT}, currend dir $(pwd)"
+bash "${BUILD_SCRIPT}"
+
+# revert to initial state after running build script
+cd "${REPO_DIR}"
+
+# create and register tag for this release if it was not manually provided
+if ! [[ $use_existing_tag ]]; then
+  log "Create new tag"
+  git tag -a "${VERSION}" -m "${VERSION}"
+  git push "https://github.com/google/hadoop-migration-assessment-tools.git" "${VERSION}"
+fi
+
+log "Prepare release notes"
+
+output="$(http_post_check_status "200" "Accept: application/vnd.github.v3+json" \
+  "https://api.github.com/repos/google/hadoop-migration-assessment-tools/releases/generate-notes" \
+  '{"tag_name":"'${VERSION}'","previous_tag_name":"'${LAST_GIT_TAG}'"}')"
+release_body="$(jq -r '.body' <<<$output)"
+
+log "Create release"
+
+payload="$(
+  jq --null-input \
+    --arg tag "${VERSION}" \
+    --arg name "${VERSION}" \
+    --arg body "${release_body}" \
+    '{ tag_name: $tag, name: $name, body: $body, draft: false }'
+)"
+
+# Create new release as a draft
+response="$(http_post_check_status "201" "Accept: application/vnd.github.v3+json" \
+  "https://api.github.com/repos/google/hadoop-migration-assessment-tools/releases" "${payload}")"
+
+log "Append zip file to the release"
+
+# Attach release binary file to the release
+release_id="$(jq -r '.id' <<<${response})"
+curl \
+  --data-binary @${RELEASE_OUTPUT_FILE} \
+  --user "${GIT_CLIENT_ID}:${GIT_CLIENT_TOKEN}" \
+  -H "Content-Type: application/octet-stream" \
+  "https://${GIT_RELEASES_USERNAME}:${GIT_PSW}@uploads.github.com/repos/google/hadoop-migration-assessment-tools/releases/${release_id}/assets?name=hadoop-migration-assessment-hooks-${VERSION}.zip"
+
+log "Release was published"
+
+# Pull just published tag
+git pull

--- a/scripts/release/release_utils.sh
+++ b/scripts/release/release_utils.sh
@@ -1,0 +1,102 @@
+#!/bin/bash
+# Copyright 2023 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License
+#
+# Display commands being run.
+# WARNING: please only enable 'set -x' if necessary for debugging, and be very
+#  careful if you handle credentials (e.g. from Keystore) with 'set -x':
+#  statements like "export VAR=$(cat /tmp/keystore/credentials)" will result in
+#  the credentials being printed in build logs.
+#  Additionally, recursive invocation with credentials as command-line
+#  parameters, will print the full command, with credentials, in the build logs.
+# set -x
+
+err() {
+  printf '%s\n' "[$(date +'%Y-%m-%dT%H:%M:%S%z')]: $*" >&2
+  exit 1
+}
+
+log() {
+  printf '%s\n' "[$(date +'%Y-%m-%dT%H:%M:%S%z')]: $*"
+}
+
+#######################################
+# makes HTTP requests and returns a status code
+# Globals:
+#   None
+# Arguments:
+#   A non optional HTTP header, a url
+# Outputs:
+#   A http status code
+#######################################
+http_get_error_code() {
+  http_header="$1"
+  http_url="$2"
+
+  http_response="$(curl -s -w "%{http_code}" -u "${GIT_CLIENT_ID}:${GIT_CLIENT_TOKEN}" -H ${http_header} ${http_url})"
+  echo $(tail -n1 <<<"${http_response}")
+}
+
+#######################################
+# makes HTTP post requests, expects given status code
+# Globals:
+#   None
+# Arguments:
+#   Expected status code
+#   A non optional HTTP header
+#   A url
+#   Content to POST
+# Outputs:
+#   A http status code
+#######################################
+http_post_check_status() {
+  expected_http_status="$1"
+  http_header="$2"
+  http_url="$3"
+  post_data="$4"
+
+  http_response="$(curl -s -w "%{http_code}" \
+    -X POST \
+    -u "${GIT_CLIENT_ID}:${GIT_CLIENT_TOKEN}" \
+    -H ${http_header} ${http_url} \
+    -d "${post_data}")"
+
+  # get the last line
+  http_response_code="$(tail -n1 <<<"${http_response}")"
+  # get all but the last line which contains the status code
+  http_response_content="$(sed '$ d' <<<"${http_response}")"
+
+  if [ "${http_response_code}" != "${expected_http_status}" ]; then
+    err "ERROR! Http request failed with code ${http_response_code}," \
+      "response content is ${http_response_content}" # write error message to stderr
+  fi
+  echo "${http_response_content:3}"
+}
+
+#######################################
+# Increments the last digit of the version tag
+# Globals:
+#   None
+# Arguments:
+#   A tag name in format vX.Y.Z
+# Outputs:
+#   A new tag name
+#######################################
+increment_tag_version() {
+  local IFS="."
+  local arr
+  read -ra arr <<<"$1"
+  arr[2]="$((arr[2] + 1))"
+  echo "${arr[*]}"
+}

--- a/scripts/release/release_utils.sh
+++ b/scripts/release/release_utils.sh
@@ -23,12 +23,12 @@
 # set -x
 
 err() {
-  printf '%s\n' "[$(date +'%Y-%m-%dT%H:%M:%S%z')]: $*" >&2
+  echo "[$(date +'%Y-%m-%dT%H:%M:%S%z')]: $*" >&2
   exit 1
 }
 
 log() {
-  printf '%s\n' "[$(date +'%Y-%m-%dT%H:%M:%S%z')]: $*"
+  echo "[$(date +'%Y-%m-%dT%H:%M:%S%z')]: $*"
 }
 
 #######################################
@@ -41,10 +41,12 @@ log() {
 #   A http status code
 #######################################
 http_get_error_code() {
-  http_header="$1"
-  http_url="$2"
+  local http_header="$1"
+  local http_url="$2"
 
-  http_response="$(curl -s -w "%{http_code}" -u "${GIT_CLIENT_ID}:${GIT_CLIENT_TOKEN}" -H ${http_header} ${http_url})"
+  local http_response="$(curl -s -w "%{http_code}" \
+    -u "${GIT_CLIENT_ID}:${GIT_CLIENT_TOKEN}" \
+    -H ${http_header} ${http_url})"
   echo $(tail -n1 <<<"${http_response}")
 }
 
@@ -61,25 +63,25 @@ http_get_error_code() {
 #   A http status code
 #######################################
 http_post_check_status() {
-  expected_http_status="$1"
-  http_header="$2"
-  http_url="$3"
-  post_data="$4"
+  local expected_http_status="$1"
+  local http_header="$2"
+  local http_url="$3"
+  local post_data="$4"
 
-  http_response="$(curl -s -w "%{http_code}" \
+  local http_response="$(curl -s -w "%{http_code}" \
     -X POST \
     -u "${GIT_CLIENT_ID}:${GIT_CLIENT_TOKEN}" \
     -H ${http_header} ${http_url} \
     -d "${post_data}")"
 
   # get the last line
-  http_response_code="$(tail -n1 <<<"${http_response}")"
+  local http_response_code="$(tail -n1 <<<"${http_response}")"
   # get all but the last line which contains the status code
-  http_response_content="$(sed '$ d' <<<"${http_response}")"
+  local http_response_content="$(sed '$ d' <<<"${http_response}")"
 
   if [ "${http_response_code}" != "${expected_http_status}" ]; then
     err "ERROR! Http request failed with code ${http_response_code}," \
-      "response content is ${http_response_content}" # write error message to stderr
+      "response content is ${http_response_content}"
   fi
   echo "${http_response_content:3}"
 }


### PR DESCRIPTION
Mostly copies the logic from the extraction tool, but with removed references to Kokoro. Kokoro integration will be done separately.  The `build.sh` script is simplified to just run tests and build the zip file – it's enough for now.

Since Github disabled authorization with password, I adjusted the code to accept client tokens. Tested on local token, should work the same way with the bot (will test it when I have an access to the account)