### PR TITLE
Capture unfinished perf logger entries

### DIFF
--- a/src/java/com/google/cloud/bigquery/dwhassessment/hooks/logger/EventRecordConstructor.java
+++ b/src/java/com/google/cloud/bigquery/dwhassessment/hooks/logger/EventRecordConstructor.java
@@ -243,11 +243,18 @@ public class EventRecordConstructor {
     return outerObj.length() > 0 ? Optional.of(outerObj.toString()) : Optional.empty();
   }
 
-  private static String dumpPerfData(PerfLogger perfLogger) {
+  private String dumpPerfData(PerfLogger perfLogger) {
     JSONObject perfObj = new JSONObject();
+    long now = clock.millis();
 
-    for (String key : perfLogger.getEndTimes().keySet()) {
-      perfObj.put(key, perfLogger.getDuration(key));
+    for (String key : perfLogger.getStartTimes().keySet()) {
+      long duration = perfLogger.getDuration(key);
+      // Some perf logger entries are finished after the hook. Make the best effort to capture them
+      // here with the duration at the current time.
+      if (duration == 0L) {
+        duration = now - perfLogger.getStartTime(key);
+      }
+      perfObj.put(key, duration);
     }
 
     return perfObj.toString();


### PR DESCRIPTION
Some perf logger entries are finished only after post hook is executed. This includes e.g. `Driver.run` and `Driver.execute`, which difference could be used to determine the queuing time for MR jobs

Assumptions is that whatever happens after the hook does not make a difference for Assessment, so it is safe to calculate the duration for the unfinished keys at the time of processing