### PR TITLE
Remove unnecessary git tag creation when passing tag directly

### DIFF
--- a/scripts/release/release.sh
+++ b/scripts/release/release.sh
@@ -72,7 +72,6 @@ else
   if [[ "${LAST_RELEASE_TAG}" ]]; then
     LAST_GIT_TAG=${LAST_RELEASE_TAG}
   fi
-  git checkout tags/"${VERSION}" -b "${VERSION}-release"
 fi
 
 log "Version name '${VERSION}' verified"


### PR DESCRIPTION
Git tag will be automatically created during the release.